### PR TITLE
Prevent dev branch being passed explicitly to get inference repo

### DIFF
--- a/script/preprocess-mlperf-inference-submission/meta.yaml
+++ b/script/preprocess-mlperf-inference-submission/meta.yaml
@@ -24,9 +24,6 @@ variations:
         - inference-src
         - submission-checker-src
         tags: mlcommons,inference,src
-        update_tags_from_env_with_prefix:
-          _branch.: 
-            - MLC_GIT_CHECKOUT 
         version: custom
   wg-automotive:
     group: benchmark_wg
@@ -34,8 +31,6 @@ variations:
       - names:
         - automotive-src
         tags: mlcommons,automotive,src
-    env:
-      MLC_GIT_CHECKOUT: master
 input_mapping:
   input: MLC_MLPERF_INFERENCE_SUBMISSION_DIR
   submission_dir: MLC_MLPERF_INFERENCE_SUBMISSION_DIR
@@ -45,7 +40,6 @@ input_mapping:
 default_env:
   MLC_MLPERF_NOINFER_LOW_ACCURACY_RESULTS: True
   MLC_MLPERF_NOINFER_SCENARIO_RESULTS: True
-  MLC_GIT_CHECKOUT: dev
 tags:
 - run
 - mlc


### PR DESCRIPTION
Potential fix for: https://github.com/mlcommons/inference/actions/runs/15565166993/job/43827328240?pr=2159