### PR TITLE
Adding support to intel oneapi 2025.2.0

### DIFF
--- a/script/get-oneapi/meta.yaml
+++ b/script/get-oneapi/meta.yaml
@@ -4,7 +4,7 @@ automation_uid: 5b4e0237da074764
 cache: true
 category: Compiler automation
 clean_files: []
-default_version: 2025.1.1
+default_version: 2025.2.0
 deps:
 - tags: detect,os
 name: Detect or install OneAPI compiler
@@ -35,12 +35,12 @@ tests:
       - fortran
 
 versions:
-  2025.1.1:
+  2025.2.0:
     env:
-      MLC_ONEAPI_INSTALL_URL_BASE: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6bfca885-4156-491e-849b-1cd7da9cc760
-      MLC_ONEAPI_INSTALL_FILENAME: intel-oneapi-base-toolkit-2025.1.1.36_offline.sh
-      MLC_ONEAPI_INSTALL_VERSION_PREFIX: '2025.1'
-      MLC_VERSION: '2025.1.1'
+      MLC_ONEAPI_INSTALL_URL_BASE: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bd1d0273-a931-4f7e-ab76-6a2a67d646c7
+      MLC_ONEAPI_INSTALL_FILENAME: intel-oneapi-base-toolkit-2025.2.0.592.sh
+      MLC_ONEAPI_INSTALL_VERSION_PREFIX: '2025.2'
+      MLC_VERSION: '2025.2.0'
 
 variations:
   path.#:


### PR DESCRIPTION
Added Intel Oneapi 2025.2.0 version support

### 🧾 PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.
