### PR TITLE
Potential fix for code scanning alert no. 13: Code injection

### DIFF
--- a/.github/workflows/test-mlperf-inference-rgat.yml
+++ b/.github/workflows/test-mlperf-inference-rgat.yml
@@ -33,9 +33,10 @@ jobs:
         pip install tabulate
     - name: Pull MLOps repository
       env:
+        REPO: ${{ github.event.pull_request.head.repo.html_url }}
         BRANCH: ${{ github.event.pull_request.head.ref }}
       run: |
-        mlc pull repo ${{ github.event.pull_request.head.repo.html_url }} --branch="$BRANCH"
+        mlc pull repo "$REPO" --branch="$BRANCH"
     - name: Test MLPerf Inference R-GAT using ${{ matrix.backend }} on ${{ matrix.os }}
       run: |
         mlcr run,mlperf,inference,generate-run-cmds,_submission,_short --pull_changes=yes --pull_inference_changes=yes  --submitter="MLCommons" --hw_name=gh_${{ matrix.os }}_x86 --model=rgat --implementation=${{ matrix.implementation }} --backend=${{ matrix.backend }} --device=cpu --scenario=Offline --test_query_count=500 --adr.compiler.tags=gcc --category=datacenter --quiet  -v --target_qps=1


### PR DESCRIPTION
Potential fix for [https://github.com/mlcommons/mlperf-automations/security/code-scanning/13](https://github.com/mlcommons/mlperf-automations/security/code-scanning/13)

To fix the code injection vulnerability, you should assign the untrusted input (`${{ github.event.pull_request.head.ref }}`) to an intermediate environment variable in the workflow step. Then in the shell command, use the native shell substitution (`$BRANCH`) rather than injecting the value in the script with GitHub Actions `${{ ... }}` syntax. This mitigates code injection risks by ensuring the shell interprets it as a single argument and not as a sequence of commands.

Specifically, edit the step "Pull MLOps repository" in `.github/workflows/test-mlperf-inference-rgat.yml`, lines 35-36, so that an environment variable (e.g., `BRANCH`) is set to `${{ github.event.pull_request.head.ref }}` and then referenced as `$BRANCH` in the shell command. No additional imports or definitions are necessary for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
