### PR TITLE
Potential fix for code scanning alert no. 12: Code injection

### DIFF
--- a/.github/workflows/test-mlperf-inference-retinanet.yml
+++ b/.github/workflows/test-mlperf-inference-retinanet.yml
@@ -45,8 +45,10 @@ jobs:
         pip install mlcflow
         pip install tabulate
     - name: Pull MLOps repo
+      env:
+        BRANCH: ${{ github.event.pull_request.head.ref }}
       run: |
-        mlc pull repo ${{ github.event.pull_request.head.repo.html_url }} --branch=${{ github.event.pull_request.head.ref }}
+        mlc pull repo ${{ github.event.pull_request.head.repo.html_url }} --branch="$BRANCH"
 
     - name: Test MLPerf Inference Retinanet using ${{ matrix.backend }} on ${{ matrix.os }}
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/test-mlperf-inference-retinanet.yml
+++ b/.github/workflows/test-mlperf-inference-retinanet.yml
@@ -46,9 +46,10 @@ jobs:
         pip install tabulate
     - name: Pull MLOps repo
       env:
+        REPO: ${{ github.event.pull_request.head.repo.html_url }}
         BRANCH: ${{ github.event.pull_request.head.ref }}
       run: |
-        mlc pull repo ${{ github.event.pull_request.head.repo.html_url }} --branch="$BRANCH"
+        mlc pull repo "$REPO" --branch="$BRANCH"
 
     - name: Test MLPerf Inference Retinanet using ${{ matrix.backend }} on ${{ matrix.os }}
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Potential fix for [https://github.com/mlcommons/mlperf-automations/security/code-scanning/12](https://github.com/mlcommons/mlperf-automations/security/code-scanning/12)

To fix this problem, we should prevent untrusted user-controlled input from being directly used in the shell context. The recommended approach is to pass the untrusted value (here, `github.event.pull_request.head.ref`) into an environment variable, and use the native shell environment variable syntax to reference it (`$BRANCH`). Specifically, for line 49: introduce an `env:` block to set the environment variable (for example, `BRANCH: ${{ github.event.pull_request.head.ref }}`), then reference it as `--branch="$BRANCH"` in the shell script. Similarly, consider also using `REPO: ${{ github.event.pull_request.head.repo.html_url }}` for consistency and security, though only the `head.ref` has been flagged.

The only required changes are within the relevant step in `.github/workflows/test-mlperf-inference-retinanet.yml`; no new imports or methods are needed, and no other files must be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
