### PR TITLE
Potential fix for code scanning alert no. 3: Code injection

### DIFF
--- a/.github/workflows/run_tests_on_modified_meta_with_secrets.yml
+++ b/.github/workflows/run_tests_on_modified_meta_with_secrets.yml
@@ -59,8 +59,11 @@ jobs:
           echo "RCLONE_CONFIG_MLC_NUSCENES_SERVICE_ACCOUNT_CREDENTIALS=${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}" >> $GITHUB_ENV
         
       - name: Process meta.yaml file
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.html_url }}
         run: |
           echo "Processing ${{ matrix.file_info.file }} (run #${{ matrix.file_info.num_run }})"
           pip install mlcflow
-          mlc pull repo ${{ github.event.pull_request.head.repo.html_url }} --branch=${{ github.event.pull_request.head.ref }}
-          mlc test script ${{ matrix.file_info.uid }} --test_input_index=${{ matrix.file_info.num_run }} --docker_mlc_repo=${{ github.event.pull_request.head.repo.html_url }} --docker_mlc_repo_branch=${{ github.event.pull_request.head.ref }} --quiet
+          mlc pull repo "$HEAD_REPO_URL" --branch="$HEAD_REF"
+          mlc test script ${{ matrix.file_info.uid }} --test_input_index=${{ matrix.file_info.num_run }} --docker_mlc_repo="$HEAD_REPO_URL" --docker_mlc_repo_branch="$HEAD_REF" --quiet

--- a/.github/workflows/run_tests_on_modified_meta_with_secrets.yml
+++ b/.github/workflows/run_tests_on_modified_meta_with_secrets.yml
@@ -59,6 +59,7 @@ jobs:
           echo "RCLONE_CONFIG_MLC_NUSCENES_SERVICE_ACCOUNT_CREDENTIALS=${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}" >> $GITHUB_ENV
         
       - name: Process meta.yaml file
+        shell: bash
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.html_url }}


### PR DESCRIPTION
Potential fix for [https://github.com/mlcommons/mlperf-automations/security/code-scanning/3](https://github.com/mlcommons/mlperf-automations/security/code-scanning/3)

To fix the problem, assign the untrusted input—`${{ github.event.pull_request.head.ref }}`—to an intermediate environment variable, then reference that environment variable in the shell command using native shell syntax (`$VAR`) instead of the `${{ ... }}` workflow interpolation. This prevents shell injection because environment variables are treated as simple strings by the shell, making it much harder for malicious content in the variable to break out of the intended usage.

Specifically:  
- Edit the step "Process meta.yaml file" at line 61–67,
- In `run:`, replace all workflow interpolations of `github.event.pull_request.head.ref` (and similarly for head.repo.html_url if desired for defense in depth) with reference to an environment variable,
- Add an `env:` block for the step, with a new environment variable, e.g. `HEAD_REF: ${{ github.event.pull_request.head.ref }}`,  
- In the `run:` script, reference this as `$HEAD_REF`.

No external libraries or dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
