### PR TITLE
Fix nvmitten crash on duplicate lscpu fields (hybrid/multi-socket CPUs)

### DIFF
--- a/script/app-mlperf-inference-nvidia/customize.py
+++ b/script/app-mlperf-inference-nvidia/customize.py
@@ -13,6 +13,28 @@ def preprocess(i):
     env = i['env']
     state = i['state']
 
+    # Patch nvmitten tree.py to tolerate duplicate keys (e.g. duplicate "model name"
+    # entries from lscpu -J on hybrid-core or multi-socket systems).
+    try:
+        import nvmitten.tree as _nvmitten_tree_mod
+        _tree_py_path = _nvmitten_tree_mod.__file__
+        with open(_tree_py_path, 'r') as _f:
+            _tree_src = _f.read()
+        if 'raise ValueError(f"Cannot insert node with duplicate name {child_node.name}")' in _tree_src and '_MLC_PATCHED_' not in _tree_src:
+            _tree_src = _tree_src.replace(
+                '        if child_node.name in self.children:\n'
+                '            raise ValueError(f"Cannot insert node with duplicate name {child_node.name}")\n'
+                '        self.children[child_node.name] = child_node',
+                '        # _MLC_PATCHED_ tolerate duplicate keys from lscpu\n'
+                '        if child_node.name in self.children:\n'
+                '            self.children[child_node.name].value = child_node.value\n'
+                '            return\n'
+                '        self.children[child_node.name] = child_node')
+            with open(_tree_py_path, 'w') as _f:
+                _f.write(_tree_src)
+    except (ImportError, OSError):
+        pass
+
     # Patch submission_checker/__init__.py if empty to expose ACC_PATTERN / MODEL_CONFIG
     # The NVIDIA harness does `import submission_checker; submission_checker.ACC_PATTERN`
     # but upstream __init__.py is empty; constants live in submission_checker/constants.py


### PR DESCRIPTION
Patch nvmitten tree.py add_child() to silently update value on duplicate keys instead of raising ValueError. This fixes CPU detection crash on systems where lscpu -J produces duplicate 'model name' entries (common on Intel hybrid-core CPUs and multi-socket AMD systems).

### 🧾 PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed

### 📝 Comments & Communication
- [ ] Proper inline comments are added to explain important or non-obvious changes
- [ ] PR title and description clearly state what the PR does and why
- [ ] Related issues (if any) are properly referenced (`Fixes #`, `Related to #`, etc.)

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed
- [ ] Paths, shell commands, and environment handling are safe and portable

