### PR TITLE
Add rsync as a dependency of remote-run-commands

### DIFF
--- a/script/remote-run-commands/meta.yaml
+++ b/script/remote-run-commands/meta.yaml
@@ -16,9 +16,13 @@ tags:
 
 # Dependencies
 deps:
+- tags: detect-os
 - tags: get,sys-util,generic,_rsync
   names:
   - rsync
+  skip_if_env:
+    MLC_HOST_OS_TYPE:
+    - windows
 
 # Environment
 default_env:

--- a/script/remote-run-commands/meta.yaml
+++ b/script/remote-run-commands/meta.yaml
@@ -14,6 +14,12 @@ tags:
 - ssh-run
 - ssh
 
+# Dependencies
+deps:
+- tags: get,sys-util,generic,_rsync
+  names:
+  - rsync
+
 # Environment
 default_env:
   MLC_SSH_CLIENT_REFRESH: '10'


### PR DESCRIPTION
Ensures rsync is installed via get-generic-sys-util before the script runs, rather than silently skipping file copies when rsync is missing.

### 🧾 PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed

### 📝 Comments & Communication
- [ ] Proper inline comments are added to explain important or non-obvious changes
- [ ] PR title and description clearly state what the PR does and why
- [ ] Related issues (if any) are properly referenced (`Fixes #`, `Related to #`, etc.)

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed
- [ ] Paths, shell commands, and environment handling are safe and portable

