### PR TITLE
fix: enable XPU (and ROCm) accelerator detection in single/multi-node…

### DIFF
--- a/script/get-mlperf-multi-node-system-info/customize.py
+++ b/script/get-mlperf-multi-node-system-info/customize.py
@@ -98,8 +98,9 @@ def preprocess(i):
 
         # set remote run tags
         rr_tags = "get,mlperf,single-node,system-info"
-        if env.get('MLC_ACCELERATOR_BACKEND', '') == 'cuda':
-            rr_tags += ",_cuda"
+        backend = env.get('MLC_ACCELERATOR_BACKEND', '')
+        if backend in ('cuda', 'rocm', 'xpu'):
+            rr_tags += f",_{backend}"
         ssh_ids = [
             s.strip() for s in env['MLC_MULTINODE_SYSTEM_SSH_IDS'].split(',') if s.strip()]
 

--- a/script/get-mlperf-single-node-system-info/meta.yaml
+++ b/script/get-mlperf-single-node-system-info/meta.yaml
@@ -26,21 +26,21 @@ deps:
 - tags: detect,cpu
 - tags: get,cuda-devices
   enable_if_env:
-    MLC_GPU_PLATFORM:
+    MLC_ACCELERATOR_BACKEND:
     - cuda
   skip_if_env:
     MLC_HOST_OS_TYPE:
     - windows
 - tags: get,rocm-devices
   enable_if_env:
-    MLC_GPU_PLATFORM:
+    MLC_ACCELERATOR_BACKEND:
     - rocm
   skip_if_env:
     MLC_HOST_OS_TYPE:
     - windows
 - tags: get,xpu-devices
   enable_if_env:
-    MLC_GPU_PLATFORM:
+    MLC_ACCELERATOR_BACKEND:
     - xpu
   skip_if_env:
     MLC_HOST_OS_TYPE:


### PR DESCRIPTION
… sysinfo

Two bugs prevented get-xpu-devices from ever being invoked:

1. get-mlperf-single-node-system-info/meta.yaml: dep enable_if_env guards referenced MLC_GPU_PLATFORM but the variations set MLC_ACCELERATOR_BACKEND, so the get,cuda-devices / get,rocm-devices / get,xpu-devices deps never fired(Second point is more critical as we were calling variations directly and not relying on env variables). Updated all three guards to check MLC_ACCELERATOR_BACKEND.

2. get-mlperf-multi-node-system-info/customize.py: remote-run tag propagation only appended _cuda for CUDA; rocm and xpu backends had no equivalent case. Replaced the if/elif chain with a single membership check covering all three.

### 🧾 PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed

### 📝 Comments & Communication
- [ ] Proper inline comments are added to explain important or non-obvious changes
- [ ] PR title and description clearly state what the PR does and why
- [ ] Related issues (if any) are properly referenced (`Fixes #`, `Related to #`, etc.)

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed
- [ ] Paths, shell commands, and environment handling are safe and portable

