### PR TITLE
Add podman_storage_root input to override container storage location …

### DIFF
--- a/automation/script/docker.py
+++ b/automation/script/docker.py
@@ -241,6 +241,10 @@ def docker_run(self_module, i):
     if quiet:
         env['MLC_QUIET'] = 'yes'
 
+    podman_storage_root = i.get('podman_storage_root', '')
+    if podman_storage_root:
+        env['MLC_PODMAN_STORAGE_ROOT'] = podman_storage_root
+
     regenerate_docker_file = not i.get('docker_noregenerate', False)
     rebuild_docker_image = i.get('docker_rebuild', False)
 

--- a/script/build-docker-image/customize.py
+++ b/script/build-docker-image/customize.py
@@ -4,6 +4,14 @@ from os.path import exists
 from utils import *
 
 
+def _get_container_cmd(env):
+    tool = env.get('MLC_CONTAINER_TOOL', 'docker')
+    storage_root = env.get('MLC_PODMAN_STORAGE_ROOT', '')
+    if tool == 'podman' and storage_root:
+        return f"{tool} --root {storage_root}/storage --runroot {storage_root}/run"
+    return tool
+
+
 def preprocess(i):
 
     os_info = i['os_info']
@@ -76,7 +84,7 @@ def preprocess(i):
 
     # Prepare CMD to build image
     XCMD = [
-        f'{env["MLC_CONTAINER_TOOL"]} build ' +
+        f'{_get_container_cmd(env)} build ' +
         env.get('MLC_DOCKER_CACHE_ARG', ''),
         secret_args,
         ' ' + build_args,

--- a/script/build-docker-image/meta.yaml
+++ b/script/build-docker-image/meta.yaml
@@ -39,6 +39,7 @@ input_mapping:
   real_run: MLC_REAL_RUN
   script_tags: MLC_DOCKER_RUN_SCRIPT_TAGS
   upload: MLC_DOCKER_PUSH_IMAGE
+  podman_storage_root: MLC_PODMAN_STORAGE_ROOT
 
 # Dependencies
 deps:

--- a/script/run-docker-container/customize.py
+++ b/script/run-docker-container/customize.py
@@ -12,6 +12,14 @@ DOCKER_SOCKET_PATH = "/var/run/docker.sock"
 NESTED_DOCKER_ENV_KEY = "MLC_DOCKER_ENABLE_NESTED"
 
 
+def _get_container_cmd(env):
+    tool = env.get('MLC_CONTAINER_TOOL', 'docker')
+    storage_root = env.get('MLC_PODMAN_STORAGE_ROOT', '')
+    if tool == 'podman' and storage_root:
+        return f"{tool} --root {storage_root}/storage --runroot {storage_root}/run"
+    return tool
+
+
 def is_valid_docker_binary(path):
     if not path:
         return False
@@ -73,7 +81,7 @@ def preprocess(i):
     logger.info('Checking existing Docker container:')
     logger.info('')
     # CMD = f"""{env['MLC_CONTAINER_TOOL']} ps --format=json  --filter "ancestor={DOCKER_CONTAINER}" """
-    CMD = f"""{env['MLC_CONTAINER_TOOL']} ps --format """ + \
+    CMD = f"""{_get_container_cmd(env)} ps --format """ + \
         '"{{ .ID }},"' + f"""  --filter "ancestor={DOCKER_CONTAINER}" """
     if os_info['platform'] == 'windows':
         CMD += " 2> nul"
@@ -112,7 +120,7 @@ def preprocess(i):
         if env.get('MLC_DOCKER_CONTAINER_ID', '') != '':
             del (env['MLC_DOCKER_CONTAINER_ID'])  # not valid ID
 
-        CMD = f"""{env['MLC_CONTAINER_TOOL']} images -q """ + DOCKER_CONTAINER
+        CMD = f"""{_get_container_cmd(env)} images -q """ + DOCKER_CONTAINER
 
         if os_info['platform'] == 'windows':
             CMD += " 2> nul"
@@ -306,14 +314,14 @@ def postprocess(i):
         # Escape single quotes inside run_cmd for bash -c '...' wrapping
         escaped_run_cmd = run_cmd.replace("'", "'\\''")
         if existing_container_id:
-            CMD = f"""ID={existing_container_id} && {env['MLC_CONTAINER_TOOL']} exec $ID bash -c '""" + \
+            CMD = f"""ID={existing_container_id} && {_get_container_cmd(env)} exec $ID bash -c '""" + \
                 escaped_run_cmd + "'"
         else:
-            CONTAINER = f"""{env['MLC_CONTAINER_TOOL']} run -dt {run_opts} --rm  {docker_image_repo}/{docker_image_name}:{docker_image_tag} bash"""
-            CMD = f"""ID=`{CONTAINER}` && {env['MLC_CONTAINER_TOOL']} exec $ID bash -c '{escaped_run_cmd}'"""
+            CONTAINER = f"""{_get_container_cmd(env)} run -dt {run_opts} --rm  {docker_image_repo}/{docker_image_name}:{docker_image_tag} bash"""
+            CMD = f"""ID=`{CONTAINER}` && {_get_container_cmd(env)} exec $ID bash -c '{escaped_run_cmd}'"""
 
             if is_true(env.get('MLC_KILL_DETACHED_CONTAINER', False)):
-                CMD += f""" && {env['MLC_CONTAINER_TOOL']} kill $ID >/dev/null"""
+                CMD += f""" && {_get_container_cmd(env)} kill $ID >/dev/null"""
 
         CMD += ' && echo "ID=$ID"'
 
@@ -375,7 +383,7 @@ def postprocess(i):
             x1 = '-it'
             x2 = " && bash ) || bash"
 
-        CONTAINER = f"{env['MLC_CONTAINER_TOOL']} run " + x1 + " --entrypoint " + x + x + " " + run_opts + \
+        CONTAINER = f"{_get_container_cmd(env)} run " + x1 + " --entrypoint " + x + x + " " + run_opts + \
             " " + docker_image_repo + "/" + docker_image_name + ":" + docker_image_tag
         # Escape quotes inside run_cmd for bash -c wrapping
         if x == "'":

--- a/script/run-docker-container/meta.yaml
+++ b/script/run-docker-container/meta.yaml
@@ -67,6 +67,7 @@ input_mapping:
   use_google_dns: MLC_DOCKER_USE_GOOGLE_DNS
   use_host_group_id: MLC_DOCKER_USE_HOST_GROUP_ID
   use_host_user_id: MLC_DOCKER_USE_HOST_USER_ID
+  podman_storage_root: MLC_PODMAN_STORAGE_ROOT
 
 # Dependencies
 deps:

--- a/script/run-mlperf-inference-app/meta.yaml
+++ b/script/run-mlperf-inference-app/meta.yaml
@@ -134,6 +134,7 @@ input_mapping:
   vllm_model_name: MLC_VLLM_SERVER_MODEL_NAME
   vllm_tp_size: MLC_MLPERF_INFERENCE_TP_SIZE
   waymo_path: MLC_DATASET_WAYMO_PATH
+  podman_storage_root: MLC_PODMAN_STORAGE_ROOT
 input_description:
   division:
     choices:


### PR DESCRIPTION
…at runtime

Adds --podman_storage_root=<path> support so Podman builds and runs can be directed to a specific storage location (e.g. /data/common/anandhu/...) without permanently modifying storage.conf. Translates to podman --root <path>/storage --runroot <path>/run for all ps, images, build, run, exec, and kill commands. Docker runs are unaffected.

### 🧾 PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed

### 📝 Comments & Communication
- [ ] Proper inline comments are added to explain important or non-obvious changes
- [ ] PR title and description clearly state what the PR does and why
- [ ] Related issues (if any) are properly referenced (`Fixes #`, `Related to #`, etc.)

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed
- [ ] Paths, shell commands, and environment handling are safe and portable

