### PR TITLE
Fix empty CPU freq/caches and ROCm GPU name in system-info output

### DIFF
--- a/script/get-mlperf-single-node-system-info/parse.py
+++ b/script/get-mlperf-single-node-system-info/parse.py
@@ -35,16 +35,21 @@ EXTRACT_RULES = {
         "type": "int",
     },
     "host_processor_frequency": {
+        # detect-cpu exposes the max clock as MLC_HOST_CPU_MAX_MHZ.
         "source": "env",
-        "candidates": ["MLC_HOST_CPU_FREQUENCY"],
+        "candidates": ["MLC_HOST_CPU_MAX_MHZ"],
     },
     "host_processor_caches": {
-        "source": "env",
-        "candidates": ["MLC_HOST_CPU_CACHES"],
+        # Composed from the per-level cache size vars emitted by detect-cpu.
+        "source": "detect",
+        "candidates": [],
     },
     "host_processor_interconnect": {
+        # No script currently probes CPU-socket interconnect (e.g. UPI/Infinity
+        # Fabric); left optional so it is omitted rather than "Not available".
         "source": "env",
         "candidates": ["MLC_HOST_CPU_INTERCONNECT"],
+        "optional": True,
     },
 
     # ---------------- Memory ----------------
@@ -271,6 +276,19 @@ def extract_value(rule, field_key):
                         and "not in lookup" not in mem_type.lower():
                     parts.append(mem_type)
                 return " ".join(parts) if parts else "Not available"
+            elif field_key == "host_processor_caches":
+                cache_levels = [
+                    ("L1d", "MLC_HOST_CPU_L1D_CACHE_SIZE"),
+                    ("L1i", "MLC_HOST_CPU_L1I_CACHE_SIZE"),
+                    ("L2", "MLC_HOST_CPU_L2_CACHE_SIZE"),
+                    ("L3", "MLC_HOST_CPU_L3_CACHE_SIZE"),
+                ]
+                parts = []
+                for label, key in cache_levels:
+                    v = os.environ.get(key, "").strip()
+                    if v:
+                        parts.append(f"{label}: {v}")
+                return "; ".join(parts) if parts else "Not available"
             elif field_key == "accelerator_on-chip_memories":
                 shared_str = os.environ.get(
                     "MLC_CUDA_DEVICE_PROP_TOTAL_AMOUNT_OF_SHARED_MEMORY_PER_BLOCK",
@@ -297,6 +315,18 @@ def extract_value(rule, field_key):
     candidates = rule.get("candidates", [])
     parts = [os.environ.get(c, "") for c in candidates]
     value = _ANSI_RE.sub('', " ".join(p for p in parts if p)).strip()
+
+    if field_key == "host_processor_frequency":
+        if not value:
+            return "Not available"
+        # MLC_HOST_CPU_MAX_MHZ is a bare MHz figure (e.g. "5137.0000").
+        try:
+            mhz = float(value.split()[0])
+        except (ValueError, IndexError):
+            return value
+        if mhz >= 1000:
+            return f"{mhz / 1000:.2f} GHz"
+        return f"{int(round(mhz))} MHz"
 
     if field_key == "accelerators_per_node":
         nums = [int(x) for x in value.split() if x.isdigit()]

--- a/script/get-rocm-devices/detect.py
+++ b/script/get-rocm-devices/detect.py
@@ -25,26 +25,31 @@ def get_gpu_info():
 
     for i in range(num_gpus):
 
+        gpu_name = ""
+        host_interconnect_result = ""
+        gpu_interconnect_result = ""
         try:
             gpu_result = subprocess.run(
                 ["amd-smi", "static", "--gpu", str(i), "--json"], capture_output=True, text=True)
             interconnect_result = subprocess.run(
                 ["amd-smi", "xgmi", "--gpu", str(i), "--json"], capture_output=True, text=True)
-            host_interconnect_result = json.loads(
-                gpu_result.stdout)["gpu_data"][0]["bus"]["pcie_interface_version"]
+            gpu_static = json.loads(gpu_result.stdout)["gpu_data"][0]
+            host_interconnect_result = gpu_static["bus"]["pcie_interface_version"]
+            # Marketing model name, e.g. "AMD Radeon RX 7700S". Strip the
+            # trademark/registered glyphs so the submission string stays ASCII.
+            gpu_name = (gpu_static.get("asic", {}).get("market_name", "") or "")
+            gpu_name = gpu_name.replace("™", "").replace("®", "").strip()
             gpu_interconnect_result = json.loads(interconnect_result.stdout)[
                 "xgmi_metric"][0][0]["link_metrics"]["link_type"]
-        except subprocess.CalledProcessError:
-            print(f"Error occurred while fetching info for GPU {i}")
+        except Exception as e:
+            print(f"Error occurred while fetching info for GPU {i}: {str(e)}")
 
-        except exception as e:
-            print(f"Some other error occurred: {str(e)}")
-            host_interconnect_result = ""
-            gpu_interconnect_result = ""
+        if not gpu_name:
+            gpu_name = f"AMD GPU {i}"
 
         gpu_info = {
             "GPU Device ID": hip.hipDeviceGetPCIBusId(STRINGLENGTH, i)[1],
-            "GPU Name": i,
+            "GPU Name": gpu_name,
             "GPU compute capability": f"{hip.hipDeviceComputeCapability(i)[1]}.{hip.hipDeviceComputeCapability(i)[2]}",
             "ROCM driver version": f"{hip.hipDriverGetVersion()[1]}",
             "ROCM runtime version": hip.hipRuntimeGetVersion()[1],


### PR DESCRIPTION
## Summary

While testing the `feat/inference-sysinfo` system-info capture on an AMD/ROCm box, several fields came back empty or wrong in both the nested and flat `_inference` outputs. This fixes the root causes.

| Field | Before | After |
|---|---|---|
| `host_processor_frequency` | `""` | `5.14 GHz` |
| `host_processor_caches` | `""` | `L1d: 256 KiB (8 instances); L1i: …; L2: 8 MiB …; L3: 16 MiB …` |
| `accelerator_model_name` | `"0"` | `AMD Radeon RX 7700S` |
| `system_size` | `"1x 0"` | `1x AMD Radeon RX 7700S` |
| `host_processor_interconnect` | `"Not available"` | omitted (optional) |

## Changes

**`get-mlperf-single-node-system-info/parse.py`** (this branch's code)
- `host_processor_frequency` read `MLC_HOST_CPU_FREQUENCY`, which nothing sets. `detect-cpu` emits `MLC_HOST_CPU_MAX_MHZ` — now read and formatted (MHz → GHz).
- `host_processor_caches` read a single `MLC_HOST_CPU_CACHES` (nonexistent). Now composed from the per-level `MLC_HOST_CPU_L1D/L1I/L2/L3_CACHE_SIZE` keys.
- `host_processor_interconnect` — no script probes socket interconnect (UPI/Infinity Fabric); marked `optional` so it is omitted rather than a misleading `"Not available"`.

**`get-rocm-devices/detect.py`** (pre-existing bug, present on `dev`/`main` too)
- `"GPU Name"` was set to the device loop index `i`, so `MLC_ROCM_DEVICE_PROP_GPU_NAME` (→ `accelerator_model_name`, `system_size`) was `"0"`. Now uses `amd-smi static` `market_name`, trademark glyphs stripped, with an `AMD GPU {i}` fallback.
- Repaired the handler `except exception` (lowercase → `NameError` on any probe failure); consolidated to `except Exception` and pre-initialized result vars so detection degrades gracefully.

## Testing

Ran `mlcr get-mlperf-multi-node-system-info,_rocm,_inference` against the local node; all fields above populate correctly (see table).

## Notes
- `host_networking_topology` remains `""` by design — it's a manual submission field.
- The `get-rocm-devices` fix is independent of the inference-sysinfo feature and affects all ROCm detection; happy to split it into its own PR against `dev` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)