### PR TITLE
add get-redfish-power-info script for Redfish BMC power capture

### DIFF
--- a/script/get-redfish-power-info/COPYRIGHT.md
+++ b/script/get-redfish-power-info/COPYRIGHT.md
@@ -1,0 +1,9 @@
+# Copyright Notice
+
+© 2026-2027 MLCommons. All Rights Reserved.
+
+This file is licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License can be obtained at:
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is provided on an "AS IS" basis, without warranties or conditions of any kind, either express or implied. Please refer to the License for the specific language governing permissions and limitations under the License.

--- a/script/get-redfish-power-info/README.md
+++ b/script/get-redfish-power-info/README.md
@@ -1,0 +1,110 @@
+# get-redfish-power-info
+
+Captures power-related fields from a Redfish BMC endpoint and writes them to a YAML file.
+
+Motivated by the MLCommons Power WG proposal ([inference_policies#324](https://github.com/mlcommons/inference_policies/pull/324), [inference#2576](https://github.com/mlcommons/inference/issues/2576)) to include nameplate / design power (PSU capacity data) in MLPerf Inference submissions.
+
+## What it does
+
+1. **Discovers** all Chassis and Systems dynamically from `/redfish/v1/` — no hardcoded IDs.
+2. **For each Chassis**, queries `/Power` (PowerControl, PowerSupplies, Voltages) and `/Thermal` (Fans, Temperatures).
+3. **For each System**, captures identity and hardware summary fields.
+4. **Writes a YAML file** whose structure mirrors the actual Redfish response — fields absent from the response are omitted entirely; arrays reflect the real count (e.g. 3 PSUs → 3 entries).
+
+## Usage
+
+### Via mlcr
+
+```bash
+mlcr get,redfish,power,info \
+    --endpoint=https://bmc.example.com \
+    --username=admin \
+    --password=secret \
+    --output=redfish_power.yaml
+```
+
+### Standalone (no mlcflow)
+
+```bash
+python3 get_redfish_power_info.py \
+    --endpoint http://localhost:8000 \
+    --output redfish_capture.yaml
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `--endpoint` | `http://localhost:8000` | Redfish base URL |
+| `--username` | `""` | BMC username (empty = no auth) |
+| `--password` | `""` | BMC password |
+| `--output` | `redfish_capture.yaml` | Output YAML file path |
+| `--insecure` | `true` | Skip TLS verification (self-signed BMC certs) |
+
+## Local testing with Redfish Mockup Server
+
+```bash
+git clone https://github.com/DMTF/Redfish-Mockup-Server.git
+cd Redfish-Mockup-Server
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python3 redfishMockupServer.py   # serves on http://localhost:8000
+```
+
+Then in another terminal:
+
+```bash
+python3 get_redfish_power_info.py --endpoint http://localhost:8000 --output test_output.yaml
+cat test_output.yaml
+```
+
+## Output format
+
+```yaml
+captured_at: "2025-07-06T10:30:00Z"
+redfish_endpoint: "http://localhost:8000"
+
+chassis:
+  - id: "1"
+    name: "..."
+    power:
+      control:
+        - name: "..."
+          consumed_watts: ...
+          capacity_watts: ...
+      power_supplies:
+        - id: "0"
+          name: "..."
+          capacity_watts: 1200
+          health: "OK"
+      voltages:
+        - name: "..."
+          reading_volts: 12.1
+    thermal:
+      fans:
+        - name: "..."
+          reading_rpm: 3200
+          health: "OK"
+      temperatures:
+        - name: "..."
+          reading_celsius: 42.0
+
+systems:
+  - id: "1"
+    name: "..."
+    model: "..."
+    manufacturer: "..."
+    power_state: "On"
+    processor_count: 2
+    processor_model: "Intel Xeon"
+    total_memory_gib: 128
+    bios_version: "P79 v1.45"
+```
+
+Only fields present in the Redfish response are included. Null values are preserved as `null`.
+
+## Output environment variable
+
+| Variable | Description |
+|---|---|
+| `MLC_REDFISH_OUTPUT_FILE_PATH` | Absolute path to the generated YAML file |

--- a/script/get-redfish-power-info/customize.py
+++ b/script/get-redfish-power-info/customize.py
@@ -7,7 +7,8 @@ def preprocess(i):
 
     python_bin = env.get('MLC_PYTHON_BIN_WITH_PATH', '').strip()
     if not python_bin:
-        return {'return': 1, 'error': 'MLC_PYTHON_BIN_WITH_PATH not set — get,python dependency failed'}
+        return {
+            'return': 1, 'error': 'MLC_PYTHON_BIN_WITH_PATH not set — get,python dependency failed'}
 
     script_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
@@ -40,7 +41,8 @@ def preprocess(i):
     else:
         cmd_parts.append('--no-insecure')
 
-    env['MLC_REDFISH_CMD'] = ' '.join(f'"{p}"' if ' ' in p else p for p in cmd_parts)
+    env['MLC_REDFISH_CMD'] = ' '.join(
+        f'"{p}"' if ' ' in p else p for p in cmd_parts)
     logger.info(f'Redfish capture command: {env["MLC_REDFISH_CMD"]}')
 
     return {'return': 0}

--- a/script/get-redfish-power-info/customize.py
+++ b/script/get-redfish-power-info/customize.py
@@ -14,9 +14,12 @@ def preprocess(i):
         'get_redfish_power_info.py'
     )
 
+    # MLC_OUTDIRNAME is set and chdir'd to by the engine before preprocess() runs.
+    # Fall back to cwd for standalone / non-mlcr invocations.
+    outdir = env.get('MLC_OUTDIRNAME', '') or os.getcwd()
     output_file = env.get('MLC_REDFISH_OUTPUT_FILE', 'redfish_capture.yaml')
     if not os.path.isabs(output_file):
-        output_file = os.path.join(os.getcwd(), output_file)
+        output_file = os.path.join(outdir, output_file)
     env['MLC_REDFISH_OUTPUT_FILE'] = output_file
 
     endpoint = env.get('MLC_REDFISH_ENDPOINT', 'http://localhost:8000')

--- a/script/get-redfish-power-info/customize.py
+++ b/script/get-redfish-power-info/customize.py
@@ -1,0 +1,57 @@
+import os
+
+
+def preprocess(i):
+    env = i['env']
+    logger = i['automation'].logger
+
+    python_bin = env.get('MLC_PYTHON_BIN_WITH_PATH', '').strip()
+    if not python_bin:
+        return {'return': 1, 'error': 'MLC_PYTHON_BIN_WITH_PATH not set — get,python dependency failed'}
+
+    script_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        'get_redfish_power_info.py'
+    )
+
+    output_file = env.get('MLC_REDFISH_OUTPUT_FILE', 'redfish_capture.yaml')
+    if not os.path.isabs(output_file):
+        output_file = os.path.join(os.getcwd(), output_file)
+    env['MLC_REDFISH_OUTPUT_FILE'] = output_file
+
+    endpoint = env.get('MLC_REDFISH_ENDPOINT', 'http://localhost:8000')
+    username = env.get('MLC_REDFISH_USERNAME', '')
+    password = env.get('MLC_REDFISH_PASSWORD', '')
+    insecure = env.get('MLC_REDFISH_INSECURE', 'yes')
+
+    cmd_parts = [python_bin, script_path,
+                 f'--endpoint={endpoint}',
+                 f'--output={output_file}']
+
+    if username:
+        cmd_parts += [f'--username={username}', f'--password={password}']
+
+    insecure_lower = insecure.lower()
+    if insecure_lower in ('yes', 'true', '1', 'on'):
+        cmd_parts.append('--insecure')
+    else:
+        cmd_parts.append('--no-insecure')
+
+    env['MLC_REDFISH_CMD'] = ' '.join(f'"{p}"' if ' ' in p else p for p in cmd_parts)
+    logger.info(f'Redfish capture command: {env["MLC_REDFISH_CMD"]}')
+
+    return {'return': 0}
+
+
+def postprocess(i):
+    env = i['env']
+    logger = i['automation'].logger
+
+    output_file = env.get('MLC_REDFISH_OUTPUT_FILE', '')
+    if output_file and os.path.exists(output_file):
+        env['MLC_REDFISH_OUTPUT_FILE_PATH'] = output_file
+        logger.info(f'Redfish power info written to: {output_file}')
+    else:
+        logger.warning(f'Expected output file not found: {output_file}')
+
+    return {'return': 0}

--- a/script/get-redfish-power-info/get_redfish_power_info.py
+++ b/script/get-redfish-power-info/get_redfish_power_info.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""
+Capture power and thermal data from a Redfish BMC endpoint and write to YAML.
+
+Walks the service root dynamically — no hardcoded IDs like Chassis/1 or Systems/1.
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from typing import Optional
+
+import yaml
+
+
+def _make_opener(insecure: bool, username: str, password: str):
+    handlers = []
+
+    if insecure:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        handlers.append(urllib.request.HTTPSHandler(context=ctx))
+
+    if username:
+        mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        mgr.add_password(None, '', username, password)
+        handlers.append(urllib.request.HTTPBasicAuthHandler(mgr))
+
+    return urllib.request.build_opener(*handlers)
+
+
+def _get(opener, url: str, timeout: int = 15) -> Optional[dict]:
+    try:
+        req = urllib.request.Request(url, headers={'Accept': 'application/json'})
+        with opener.open(req, timeout=timeout) as resp:
+            raw = resp.read()
+            return json.loads(raw)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        print(f"  HTTP {e.code} fetching {url}", file=sys.stderr)
+        return None
+    except Exception as exc:
+        print(f"  Error fetching {url}: {exc}", file=sys.stderr)
+        return None
+
+
+def _members(data: Optional[dict]) -> list[str]:
+    """Extract @odata.id hrefs from a Members array."""
+    if not data:
+        return []
+    return [m.get('@odata.id', '') for m in data.get('Members', []) if m.get('@odata.id')]
+
+
+def _id_from_url(url: str) -> str:
+    return url.rstrip('/').split('/')[-1]
+
+
+# ---------------------------------------------------------------------------
+# Per-resource extractors
+# ---------------------------------------------------------------------------
+
+def _extract_power_control(entry: dict) -> dict:
+    out = {}
+    for k in ('Name', 'PowerConsumedWatts', 'PowerCapacityWatts',
+               'PowerAvailableWatts', 'PowerAllocatedWatts', 'PowerRequestedWatts'):
+        if k in entry:
+            out[_to_snake(k)] = entry[k]
+    metrics = entry.get('PowerMetrics', {}) or {}
+    if metrics:
+        for mk, ok in (('AverageConsumedWatts', 'average_watts'),
+                       ('MaxConsumedWatts', 'max_watts'),
+                       ('MinConsumedWatts', 'min_watts'),
+                       ('IntervalInMin', 'interval_minutes')):
+            if mk in metrics:
+                out[ok] = metrics[mk]
+    limit = entry.get('PowerLimit', {}) or {}
+    if limit and limit.get('LimitInWatts') is not None:
+        out['limit_watts'] = limit['LimitInWatts']
+    status = entry.get('Status', {}) or {}
+    if status.get('Health') is not None:
+        out['health'] = status['Health']
+    if status.get('State') is not None:
+        out['state'] = status['State']
+    return out
+
+
+def _extract_psu(entry: dict) -> dict:
+    out = {}
+    for k, ok in (
+        ('MemberId', 'id'),
+        ('Name', 'name'),
+        ('PowerCapacityWatts', 'capacity_watts'),
+        ('LastPowerOutputWatts', 'last_output_watts'),
+        ('LineInputVoltage', 'input_voltage'),
+        ('LineInputVoltageType', 'input_voltage_type'),
+        ('PowerSupplyType', 'type'),
+        ('Model', 'model'),
+        ('Manufacturer', 'manufacturer'),
+        ('SerialNumber', 'serial_number'),
+        ('FirmwareVersion', 'firmware_version'),
+        ('PartNumber', 'part_number'),
+        ('SparePartNumber', 'spare_part_number'),
+    ):
+        if k in entry:
+            out[ok] = entry[k]
+    # InputRanges: rated output wattage per input voltage range — the nameplate data
+    input_ranges = entry.get('InputRanges') or []
+    if input_ranges:
+        _ir_map = (('InputType', 'input_type'), ('MinimumVoltage', 'minimum_voltage'),
+                   ('MaximumVoltage', 'maximum_voltage'), ('OutputWattage', 'output_wattage'))
+        out['input_ranges'] = [
+            {ok: ir[k] for k, ok in _ir_map if k in ir}
+            for ir in input_ranges
+        ]
+    status = entry.get('Status', {}) or {}
+    if status.get('Health') is not None:
+        out['health'] = status['Health']
+    if status.get('State') is not None:
+        out['state'] = status['State']
+    return out
+
+
+def _extract_voltage(entry: dict) -> dict:
+    out = {}
+    for k, ok in (
+        ('Name', 'name'),
+        ('ReadingVolts', 'reading_volts'),
+        ('UpperThresholdNonCritical', 'upper_threshold_non_critical'),
+        ('UpperThresholdCritical', 'upper_threshold_critical'),
+        ('LowerThresholdNonCritical', 'lower_threshold_non_critical'),
+        ('LowerThresholdCritical', 'lower_threshold_critical'),
+    ):
+        if k in entry:
+            out[ok] = entry[k]
+    status = entry.get('Status', {}) or {}
+    if status.get('Health') is not None:
+        out['health'] = status['Health']
+    return out
+
+
+def _extract_fan(entry: dict) -> dict:
+    out = {}
+    for k, ok in (
+        ('MemberId', 'id'),
+        ('FanName', 'name'),
+        ('Name', 'name'),
+        ('PhysicalContext', 'physical_context'),
+        # ReadingRPM (older Redfish) takes precedence; fallback to Reading+ReadingUnits (newer)
+        ('ReadingRPM', 'reading_rpm'),
+        ('Reading', 'reading'),
+        ('ReadingUnits', 'reading_units'),
+        ('UpperThresholdNonCritical', 'upper_threshold_non_critical'),
+        ('UpperThresholdCritical', 'upper_threshold_critical'),
+        ('LowerThresholdNonCritical', 'lower_threshold_non_critical'),
+        ('LowerThresholdCritical', 'lower_threshold_critical'),
+    ):
+        if k in entry and ok not in out:
+            out[ok] = entry[k]
+    status = entry.get('Status', {}) or {}
+    if status.get('Health') is not None:
+        out['health'] = status['Health']
+    if status.get('State') is not None:
+        out['state'] = status['State']
+    return out
+
+
+def _extract_temperature(entry: dict) -> dict:
+    out = {}
+    for k, ok in (
+        ('Name', 'name'),
+        ('ReadingCelsius', 'reading_celsius'),
+        ('UpperThresholdNonCritical', 'upper_threshold_non_critical'),
+        ('UpperThresholdCritical', 'upper_threshold_critical'),
+        ('LowerThresholdNonCritical', 'lower_threshold_non_critical'),
+        ('LowerThresholdCritical', 'lower_threshold_critical'),
+        ('PhysicalContext', 'physical_context'),
+    ):
+        if k in entry:
+            out[ok] = entry[k]
+    status = entry.get('Status', {}) or {}
+    if status.get('Health') is not None:
+        out['health'] = status['Health']
+    return out
+
+
+def _to_snake(name: str) -> str:
+    """CamelCase → snake_case for the simple cases we encounter."""
+    s = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1_\2', name)
+    s = re.sub(r'([a-z\d])([A-Z])', r'\1_\2', s)
+    return s.lower()
+
+
+# ---------------------------------------------------------------------------
+# Chassis and Systems collection
+# ---------------------------------------------------------------------------
+
+def collect_chassis(opener, base: str, chassis_url: str) -> dict:
+    chassis_list = _members(_get(opener, base + chassis_url))
+    results = []
+    for href in chassis_list:
+        chassis_id = _id_from_url(href)
+        chassis_data = _get(opener, base + href)
+        if not chassis_data:
+            continue
+
+        entry: dict = {'id': chassis_id}
+        for k, ok in (('Name', 'name'), ('ChassisType', 'chassis_type'),
+                       ('Manufacturer', 'manufacturer'), ('Model', 'model'),
+                       ('SerialNumber', 'serial_number'), ('SKU', 'sku')):
+            if k in chassis_data:
+                entry[ok] = chassis_data[k]
+        status = chassis_data.get('Status', {}) or {}
+        if status.get('Health'):
+            entry['health'] = status['Health']
+
+        # Power
+        power_href = (chassis_data.get('Power', {}) or {}).get('@odata.id', '')
+        if not power_href:
+            power_href = f'{chassis_url}/{chassis_id}/Power'
+        power_data = _get(opener, base + power_href)
+        if power_data:
+            power_block = {}
+
+            ctrl_list = [_extract_power_control(c)
+                         for c in power_data.get('PowerControl', []) or []
+                         if c]
+            if ctrl_list:
+                power_block['control'] = ctrl_list
+
+            psu_list = [_extract_psu(p)
+                        for p in power_data.get('PowerSupplies', []) or []
+                        if p]
+            if psu_list:
+                power_block['power_supplies'] = psu_list
+
+            volt_list = [_extract_voltage(v)
+                         for v in power_data.get('Voltages', []) or []
+                         if v]
+            if volt_list:
+                power_block['voltages'] = volt_list
+
+            if power_block:
+                entry['power'] = power_block
+
+        # Thermal
+        thermal_href = (chassis_data.get('Thermal', {}) or {}).get('@odata.id', '')
+        if not thermal_href:
+            thermal_href = f'{chassis_url}/{chassis_id}/Thermal'
+        thermal_data = _get(opener, base + thermal_href)
+        if thermal_data:
+            thermal_block = {}
+
+            fan_list = [_extract_fan(f)
+                        for f in thermal_data.get('Fans', []) or []
+                        if f]
+            if fan_list:
+                thermal_block['fans'] = fan_list
+
+            temp_list = [_extract_temperature(t)
+                         for t in thermal_data.get('Temperatures', []) or []
+                         if t]
+            if temp_list:
+                thermal_block['temperatures'] = temp_list
+
+            if thermal_block:
+                entry['thermal'] = thermal_block
+
+        results.append(entry)
+
+    return results
+
+
+def collect_systems(opener, base: str, systems_url: str) -> list:
+    systems_list = _members(_get(opener, base + systems_url))
+    results = []
+    for href in systems_list:
+        system_id = _id_from_url(href)
+        data = _get(opener, base + href)
+        if not data:
+            continue
+
+        entry: dict = {'id': system_id}
+        for k, ok in (
+            ('Name', 'name'),
+            ('Model', 'model'),
+            ('Manufacturer', 'manufacturer'),
+            ('SerialNumber', 'serial_number'),
+            ('SKU', 'sku'),
+            ('HostName', 'hostname'),
+            ('PowerState', 'power_state'),
+            ('BiosVersion', 'bios_version'),
+            ('PartNumber', 'part_number'),
+            ('SystemType', 'system_type'),
+        ):
+            if k in data:
+                entry[ok] = data[k]
+
+        proc_summary = data.get('ProcessorSummary', {}) or {}
+        if proc_summary.get('Count') is not None:
+            entry['processor_count'] = proc_summary['Count']
+        if proc_summary.get('Model'):
+            entry['processor_model'] = proc_summary['Model']
+
+        mem_summary = data.get('MemorySummary', {}) or {}
+        total_gib = mem_summary.get('TotalSystemMemoryGiB')
+        if total_gib is not None:
+            entry['total_memory_gib'] = total_gib
+
+        storage = data.get('Storage', {}) or {}
+        if storage.get('@odata.id'):
+            entry['storage_url'] = storage['@odata.id']
+
+        results.append(entry)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Capture Redfish power/thermal/system info and write to YAML'
+    )
+    parser.add_argument('--endpoint', default='http://localhost:8000',
+                        help='Redfish base URL (default: http://localhost:8000)')
+    parser.add_argument('--username', default='',
+                        help='BMC username (leave empty for unauthenticated mockup)')
+    parser.add_argument('--password', default='',
+                        help='BMC password')
+    parser.add_argument('--output', default='redfish_capture.yaml',
+                        help='Output YAML file path (default: redfish_capture.yaml)')
+    parser.add_argument('--insecure', action='store_true', default=True,
+                        help='Skip TLS certificate verification (default: true)')
+    parser.add_argument('--no-insecure', dest='insecure', action='store_false',
+                        help='Enforce TLS certificate verification')
+    args = parser.parse_args()
+
+    output_path = args.output
+    output_dir = os.path.dirname(os.path.abspath(output_path))
+    if not os.path.isdir(output_dir):
+        print(f'ERROR: Output directory does not exist: {output_dir}', file=sys.stderr)
+        sys.exit(1)
+
+    base = args.endpoint.rstrip('/')
+    opener = _make_opener(args.insecure, args.username, args.password)
+
+    print(f'Connecting to Redfish endpoint: {base}', flush=True)
+    service_root = _get(opener, base + '/redfish/v1/')
+    if not service_root:
+        print('ERROR: Could not reach Redfish service root at /redfish/v1/', file=sys.stderr)
+        sys.exit(1)
+
+    chassis_url = (service_root.get('Chassis', {}) or {}).get('@odata.id', '/redfish/v1/Chassis')
+    systems_url = (service_root.get('Systems', {}) or {}).get('@odata.id', '/redfish/v1/Systems')
+
+    print(f'Discovering Chassis from {chassis_url}', flush=True)
+    chassis_results = collect_chassis(opener, base, chassis_url)
+    print(f'  Found {len(chassis_results)} chassis')
+
+    print(f'Discovering Systems from {systems_url}', flush=True)
+    systems_results = collect_systems(opener, base, systems_url)
+    print(f'  Found {len(systems_results)} systems')
+
+    output = {
+        'captured_at': datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'redfish_endpoint': base,
+    }
+    if chassis_results:
+        output['chassis'] = chassis_results
+    if systems_results:
+        output['systems'] = systems_results
+
+    with open(output_path, 'w') as f:
+        yaml.dump(output, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    print(f'Output written to: {output_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/script/get-redfish-power-info/meta.yaml
+++ b/script/get-redfish-power-info/meta.yaml
@@ -1,0 +1,48 @@
+alias: get-redfish-power-info
+uid: 9a257ca2de162d08
+automation_alias: script
+automation_uid: 5b4e0237da074764
+
+# Metadata
+category: Platform information
+tags:
+- get
+- redfish
+- power
+- info
+- bmc
+
+# Cache
+cache: false
+
+# Environment
+new_env_keys:
+- MLC_REDFISH_OUTPUT_FILE_PATH
+
+# Input mapping
+input_mapping:
+  endpoint: MLC_REDFISH_ENDPOINT
+  username: MLC_REDFISH_USERNAME
+  password: MLC_REDFISH_PASSWORD
+  output: MLC_REDFISH_OUTPUT_FILE
+  insecure: MLC_REDFISH_INSECURE
+
+default_env:
+  MLC_REDFISH_ENDPOINT: http://localhost:8000
+  MLC_REDFISH_USERNAME: ''
+  MLC_REDFISH_PASSWORD: ''
+  MLC_REDFISH_OUTPUT_FILE: redfish_capture.yaml
+  MLC_REDFISH_INSECURE: 'yes'
+
+# Dependencies
+deps:
+- tags: detect,os
+- names:
+  - python
+  - python3
+  tags: get,python
+- tags: get,generic-python-lib,_package.PyYAML
+
+# Output / debugging
+print_env_at_the_end:
+  MLC_REDFISH_OUTPUT_FILE_PATH: Path to the generated Redfish power info YAML file.

--- a/script/get-redfish-power-info/meta.yaml
+++ b/script/get-redfish-power-info/meta.yaml
@@ -17,6 +17,7 @@ cache: false
 
 # Environment
 new_env_keys:
+- MLC_OUTDIRNAME
 - MLC_REDFISH_OUTPUT_FILE_PATH
 
 # Input mapping

--- a/script/get-redfish-power-info/run.bat
+++ b/script/get-redfish-power-info/run.bat
@@ -1,0 +1,3 @@
+@echo off
+%MLC_REDFISH_CMD%
+if errorlevel 1 exit /b 1

--- a/script/get-redfish-power-info/run.sh
+++ b/script/get-redfish-power-info/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+eval "${MLC_REDFISH_CMD}"
+EXIT_CODE=$?
+test ${EXIT_CODE} -eq 0 || exit ${EXIT_CODE}


### PR DESCRIPTION
Captures power and thermal data from a Redfish BMC endpoint and writes to YAML. Motivated by the MLCommons Power WG nameplate/design power proposal (inference_policies#324, inference#2576).

Discovers Chassis and Systems dynamically from the Redfish service root — no hardcoded IDs. For each Chassis queries /Power (PowerControl with health/state/allocated watts, PowerSupplies with InputRanges rated capacity data, Voltages) and /Thermal (Fans with id/context, Temperatures). For each System captures identity and hardware summary. Output shape mirrors the real Redfish response — absent sections are omitted, not stubbed with nulls.

Tested standalone and end-to-end via mlcr against the DMTF Redfish Mockup Server.

### 🧾 PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed

### 📝 Comments & Communication
- [ ] Proper inline comments are added to explain important or non-obvious changes
- [ ] PR title and description clearly state what the PR does and why
- [ ] Related issues (if any) are properly referenced (`Fixes #`, `Related to #`, etc.)

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed
- [ ] Paths, shell commands, and environment handling are safe and portable

