### PR TITLE
Remove temporary r6.1 inference-src branch pin (MLC_TMP_GIT_CHECKOUT)

### DIFF
--- a/script/get-mlperf-inference-src/meta.yaml
+++ b/script/get-mlperf-inference-src/meta.yaml
@@ -208,7 +208,6 @@ versions:
   r6.1:
     env:
       MLC_MLPERF_LAST_RELEASE: v6.1
-      MLC_TMP_GIT_CHECKOUT: submission_checker_constants_update
   tvm:
     env:
       MLC_MLPERF_LAST_RELEASE: v3.1


### PR DESCRIPTION
## Summary
- Removes `MLC_TMP_GIT_CHECKOUT: submission_checker_constants_update` from the `r6.1` version block in `script/get-mlperf-inference-src/meta.yaml`.
- This temporary pin (added in #1024) forced `inference-src` to a dev branch whenever `run-mlperf-inference-app`'s default `r6.1-dev` variation resolved the `inference-src` version to `r6.1`.
- It conflicted with any explicit `--adr.inference-src` branch/version override (e.g. CI jobs testing a PR branch directly against `mlcommons/inference`), causing `get-mlperf-inference-src/customize.py` to abort with:
  ```
  Error: Conflicting branches between version assigned and user specified.
  ```
  because `MLC_GIT_CHECKOUT` (user-specified branch) and `MLC_TMP_GIT_CHECKOUT` (version-pinned branch) disagreed.

## Test plan
- [ ] Re-run the previously failing job (`mlcr run,mlperf,inference,generate-run-cmds,_submission,_short` for bert-99/onnxruntime) against a PR branch and confirm it no longer hits the conflicting-branches error.
- [ ] Confirm r6.1 submission-checker behavior is unaffected now that `inference-src` for `r6.1` tracks its normal default (`master`/explicit override) instead of the pinned `submission_checker_constants_update` branch — re-verify if the submission-checker constants update from that branch is still required and, if so, merge it upstream instead of pinning here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)