### PR TITLE
Add Phase-1 prototype entry point for mlcflow's pip-package discovery

### DIFF
--- a/mlc_scripts_content/script/demo-detect-arch/customize.py
+++ b/mlc_scripts_content/script/demo-detect-arch/customize.py
@@ -1,0 +1,11 @@
+import platform
+
+
+def preprocess(i):
+    env = i['env']
+    env['MLC_DEMO_ARCH'] = platform.machine()
+    return {'return': 0}
+
+
+def postprocess(i):
+    return {'return': 0}

--- a/mlc_scripts_content/script/demo-detect-arch/meta.yaml
+++ b/mlc_scripts_content/script/demo-detect-arch/meta.yaml
@@ -1,0 +1,15 @@
+alias: demo-detect-arch
+uid: "2222222222222222"
+automation_alias: script
+automation_uid: 5b4e0237da074764
+
+category: Demo
+
+tags:
+- demo
+- detect
+- arch
+- mlc-scripts-content
+
+new_env_keys:
+- MLC_DEMO_ARCH

--- a/mlc_scripts_content/script/demo-detect-arch/run.sh
+++ b/mlc_scripts_content/script/demo-detect-arch/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Detected arch: ${MLC_DEMO_ARCH}"
+exit 0

--- a/mlc_scripts_content/script/demo-hello/customize.py
+++ b/mlc_scripts_content/script/demo-hello/customize.py
@@ -1,0 +1,9 @@
+def preprocess(i):
+    env = i['env']
+    env['MLC_DEMO_HELLO_MESSAGE'] = 'Hello from the pip-installed mlc-scripts-content package!'
+    env['MLC_DEMO_HOST_OS'] = env.get('MLC_HOST_OS_TYPE', 'unknown')
+    return {'return': 0}
+
+
+def postprocess(i):
+    return {'return': 0}

--- a/mlc_scripts_content/script/demo-hello/meta.yaml
+++ b/mlc_scripts_content/script/demo-hello/meta.yaml
@@ -1,0 +1,20 @@
+alias: demo-hello
+uid: "1111111111111111"
+automation_alias: script
+automation_uid: 5b4e0237da074764
+
+category: Demo
+
+tags:
+- demo
+- hello
+- mlc-scripts-content
+
+new_env_keys:
+- MLC_DEMO_HELLO_MESSAGE
+- MLC_DEMO_HOST_OS
+
+# Depends on the real, git-cloned mlperf-automations repo's detect-os script
+# to exercise cross-repo (pip-sourced -> git-cloned) dependency resolution.
+deps:
+- tags: detect,os

--- a/mlc_scripts_content/script/demo-hello/run.sh
+++ b/mlc_scripts_content/script/demo-hello/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "${MLC_DEMO_HELLO_MESSAGE}"
+echo "Host OS (via cross-repo dep on git-cloned detect-os): ${MLC_DEMO_HOST_OS}"
+exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,16 @@ Documentation = "https://docs.mlcommons.org/mlperf-automations"
 Repository = "https://github.com/mlcommons/mlperf-automations"
 Issues = "https://github.com/mlcommons/mlperf-automations/issues"
 
+# Phase-1 prototype: advertises a small demo script-content package to
+# mlcflow's pip-package discovery mechanism (see
+# mlcflow-pip-script-packages-proposal.pptx). NOT the real 377-script
+# tree - that migration is a separate, later phase. mlc_scripts_content/
+# is a new, minimal package distinct from automation/ (left untouched).
+[project.entry-points."mlc.script_packages"]
+mlc-scripts = "mlc_scripts_content"
+
 [tool.setuptools]
-packages = []
+packages = ["mlc_scripts_content"]
 include-package-data = true
 
 [tool.setuptools.dynamic]
@@ -41,3 +49,4 @@ version = {file = "VERSION"}
 
 [tool.setuptools.package-data]
 "mlcr" = ["README.md", "VERSION", "git_commit_hash.txt"]
+"mlc_scripts_content" = ["script/**/*"]


### PR DESCRIPTION
## Summary
- Declares the `mlc.script_packages` entry point that mlcflow's new pip-package discovery mechanism looks for (mlcflow PR: https://github.com/mlcommons/mlcflow/pull/271).
- Adds a small `mlc_scripts_content/` package with two demo scripts (`demo-hello`, `demo-detect-arch`) to prove the mechanism end-to-end.
- `demo-hello` deliberately depends on this repo's real, git-cloned `detect-os` script (`tags: detect,os`) to exercise cross-repo (pip → git) dependency resolution.
- `pyproject.toml`: `packages` changed from `[]` to `["mlc_scripts_content"]`, entry-point declaration added, `package-data` glob added for the `script/` subtree.

**This is a Phase-1 prototype, not a migration of the real 377-script tree** — that remains exactly as-is, fetched via git as before. `automation/` is also completely untouched (kept for backward compatibility, per the earlier decision not to remove it yet).

See the companion mlcflow PR for the discovery mechanism itself, and the follow-up issue on mlcflow proposing the longer-term migration of script content to a properly packaged pip distribution.

## Test plan
- [x] Built the wheel from this branch and verified `mlc_scripts_content/` (incl. `meta.yaml`/`customize.py`/`run.sh` for both demo scripts) is packaged correctly, `automation/` and the real `script/` tree are excluded
- [x] Verified end-to-end in a clean Docker container (fresh `python:3.11-slim`, no host state): `demo-hello` resolves its dependency on this repo's git-cloned `detect-os` script and runs correctly
- [x] Verified a second, differently-named "fork" test package coexists with this one with zero collision (distribution-name-based aliasing, not entry-point-name-based)
- [x] Verified backward compatibility: a classic git-clone-only setup (this repo registered normally, its own `automation/` folder still present, no pip packages installed) works with zero regression
- [x] Verified the mixed case: this repo registered normally (with its `automation/` folder intact) *and* the pip package installed at the same time — no conflicts, both content sources resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)