### PR TITLE
Mark the bundled automation engine as frozen and deprecated

### DIFF
--- a/.github/workflows/automation-frozen-notice.yml
+++ b/.github/workflows/automation-frozen-notice.yml
@@ -1,0 +1,59 @@
+# Warns (never blocks) when a PR modifies the frozen automation/ engine copy.
+#
+# Uses pull_request_target so the job has a write token for PRs from forks -
+# which is exactly the case this notice is aimed at. This is safe here only
+# because the job never checks out or executes PR-authored code; it reads the
+# event payload and calls the API, nothing else. Do not add actions/checkout.
+name: Notice - automation engine is frozen
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'automation/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  notice:
+    if: github.repository_owner == 'mlcommons'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post or update the frozen-engine notice
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const marker = '<!-- automation-frozen-notice -->';
+            const body = [
+              marker,
+              '### :warning: This PR modifies `automation/` — the frozen engine copy',
+              '',
+              'The MLC script automation engine now lives in ' +
+              '[mlcflow](https://github.com/mlcommons/mlcflow) and ships bundled with it. ' +
+              'The copy in this repo is kept **only** as a fallback for `mlcflow <= 1.2.9`, ' +
+              'and is ignored entirely by `mlcflow >= 1.3.0`.',
+              '',
+              '**A change here will not reach anyone running a current mlcflow.** ' +
+              'Engine changes belong in a PR against mlcflow — see `automation/README.md`.',
+              '',
+              'This is a warning, not a block: fixes aimed at the fallback copy are ' +
+              'still legitimate while it ships.',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number }
+            );
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment(
+                { owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment(
+                { owner, repo, issue_number, body });
+            }

--- a/.github/workflows/automation-frozen-notice.yml
+++ b/.github/workflows/automation-frozen-notice.yml
@@ -17,7 +17,6 @@ permissions:
 
 jobs:
   notice:
-    if: github.repository_owner == 'mlcommons'
     runs-on: ubuntu-latest
     steps:
       - name: Post or update the frozen-engine notice

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,42 @@
+# This engine is frozen — it has moved to mlcflow
+
+The MLC script automation engine in this directory (`automation/utils.py` and
+`automation/script/*`) is now maintained in
+**[mlcflow](https://github.com/mlcommons/mlcflow)**, under `automation/` there,
+and ships bundled with every `mlcflow` install.
+
+**The copy here is frozen.** It is kept only so that `mlcflow <= 1.2.9`, which
+predates the migration and has no bundled engine, still has one to fall back
+on. `mlcflow >= 1.3.0` loads its own bundled copy and ignores this directory
+entirely. Once the grace period ends, this directory will be removed.
+
+This repository keeps the script **content** — the 350+ `script/<alias>/`
+directories with their `meta.yaml`, `customize.py` and `run.sh`.
+
+## Where things went
+
+| Was here | Now in mlcflow |
+|---|---|
+| `automation/script/module.py` | `automation/script/module.py` |
+| `automation/script/cache_utils.py` | `automation/script/cache_utils.py` |
+| `automation/script/docker.py`, `docker_utils.py` | same paths |
+| `automation/script/apptainer.py`, `remote_run.py` | same paths |
+| `automation/script/meta_schema.py`, `lint.py`, `doc.py`, `help.py`, `validate.py`, `experiment.py`, `script_utils.py` | same paths |
+| `automation/utils.py` | `automation/utils.py` |
+
+## What this means for you
+
+- **Editing engine behaviour? Open a PR against
+  [mlcflow](https://github.com/mlcommons/mlcflow), not this repo.** A change
+  made here reaches nobody running a current mlcflow — it only affects users
+  still on the deprecated fallback path.
+- **`from utils import ...` in a `customize.py` still works.** mlcflow puts its
+  bundled `automation/` directory on `sys.path` before loading a script, so
+  that import resolves against `mlcflow/automation/utils.py`. Nothing in
+  `script/` needs to change.
+- **On an older mlcflow?** It still runs, using this fallback copy, and will
+  warn you once per run. Upgrade with `pip install --upgrade mlcflow` to get
+  mlcflow >= 1.3.0 and the maintained engine.
+
+This file is a signpost, not code. It can be deleted along with the rest of
+this directory once the fallback is no longer needed.

--- a/automation/script/deprecation.py
+++ b/automation/script/deprecation.py
@@ -64,11 +64,11 @@ def notify_if_deprecated(logger):
         os.environ[_ENV_SENTINEL] = 'yes'
 
         logger.warning(
-            'Your mlcflow version ({}) is deprecated and will stop being supported soon.\n'
-            '  The MLC script automation engine has moved into mlcflow itself and now ships with it.\n'
-            '  This run is using the older fallback copy kept in mlcommons@mlperf-automations,\n'
-            '  which will be removed once the migration is complete.\n'
-            '  Please upgrade to mlcflow >= {}:  pip install --upgrade mlcflow'.format(
+            '''Your mlcflow version ({}) is deprecated and will stop being supported soon.
+  The MLC script automation engine has moved into mlcflow itself and now ships with it.
+  This run is using the older fallback copy kept in mlcommons@mlperf-automations,
+  which will be removed once the migration is complete.
+  Please upgrade to mlcflow >= {}:  pip install --upgrade mlcflow'''.format(
                 current_version, MIN_MLCFLOW_VERSION))
 
     except Exception:

--- a/automation/script/deprecation.py
+++ b/automation/script/deprecation.py
@@ -1,0 +1,76 @@
+# One-time notice for users still running the engine copy kept in this repo.
+#
+# mlcflow >= 1.3.0 bundles its own copy of automation/ and never loads this
+# one, so reaching this code means the installed mlcflow predates the
+# migration of the engine into mlcflow.
+
+import os
+
+from utils import compare_versions
+
+MIN_MLCFLOW_VERSION = "1.3.0"
+
+_ENV_SENTINEL = "MLC_ENGINE_DEPRECATION_NOTICE_SHOWN"
+
+_notice_shown = False
+
+
+def get_mlcflow_version():
+    """
+    Best-effort lookup of the installed mlcflow version.
+
+    Returns the version string, or None if it cannot be determined.
+    """
+
+    # The distribution is named "mlcflow" - note that looking up "mlc"
+    # always raises PackageNotFoundError.
+    try:
+        from importlib.metadata import version
+        return version("mlcflow")
+    except Exception:
+        pass
+
+    try:
+        import mlc
+        return mlc.__version__
+    except Exception:
+        return None
+
+
+def notify_if_deprecated(logger):
+    """
+    Warn once per process that this copy of the engine is deprecated.
+
+    Stays silent when the installed mlcflow is recent enough, or when its
+    version cannot be determined. Never raises.
+    """
+
+    global _notice_shown
+
+    if _notice_shown or os.environ.get(_ENV_SENTINEL):
+        return
+
+    try:
+        current_version = get_mlcflow_version()
+        if not current_version:
+            return
+
+        r = compare_versions({'version1': current_version,
+                              'version2': MIN_MLCFLOW_VERSION})
+        if r.get('return', 0) > 0 or r.get('comparison', 0) >= 0:
+            return
+
+        _notice_shown = True
+        os.environ[_ENV_SENTINEL] = 'yes'
+
+        logger.warning(
+            'Your mlcflow version ({}) is deprecated and will stop being supported soon.\n'
+            '  The MLC script automation engine has moved into mlcflow itself and now ships with it.\n'
+            '  This run is using the older fallback copy kept in mlcommons@mlperf-automations,\n'
+            '  which will be removed once the migration is complete.\n'
+            '  Please upgrade to mlcflow >= {}:  pip install --upgrade mlcflow'.format(
+                current_version, MIN_MLCFLOW_VERSION))
+
+    except Exception:
+        # Showing a notice must never be able to break a run.
+        pass

--- a/automation/script/module.py
+++ b/automation/script/module.py
@@ -18,6 +18,7 @@ import mlc.utils as utils
 from utils import *
 from script.script_utils import *
 from script.cache_utils import *
+from script.deprecation import notify_if_deprecated
 
 
 class ScriptAutomation(Automation):
@@ -34,6 +35,10 @@ class ScriptAutomation(Automation):
         self.file_with_cached_state = 'mlc-cached-state.json'
         self.logger = self.action_object.logger
         self.logger.propagate = False
+
+        # This engine copy is only loaded by mlcflow versions that predate the
+        # migration of the engine into mlcflow itself - tell the user once.
+        notify_if_deprecated(self.logger)
 
         # Create CacheAction using the same parent as the Script
         self.cache_action = CacheAction(self.action_object.parent)


### PR DESCRIPTION
## What

The MLC script automation engine has moved into [mlcflow](https://github.com/mlcommons/mlcflow), where it ships bundled at `<site-packages>/automation/`. mlcflow >= 1.3.0 resolves the engine through `bundled_automation_path()` and never reads this repo's `automation/` folder.

The folder is **kept, not deleted**, so that mlcflow <= 1.2.9 still finds a working engine. This PR adds the two signals that grace period needs. It changes no engine behaviour.

## 1. Runtime notice for users on an old mlcflow

New `automation/script/deprecation.py` warns once per run:

```
Your mlcflow version (1.2.9) is deprecated and will stop being supported soon.
  The MLC script automation engine has moved into mlcflow itself and now ships with it.
  This run is using the older fallback copy kept in mlcommons@mlperf-automations,
  which will be removed once the migration is complete.
  Please upgrade to mlcflow >= 1.3.0:  pip install --upgrade mlcflow
```

Executing this code at all means the repo copy was loaded, i.e. the installed mlcflow predates the migration. The version check only makes the message accurate; it is not what detects the condition.

Three implementation notes worth reviewing:

- **The once-per-run flag is in a sibling module, not `module.py`.** mlcflow's `dynamic_import_module()` loads `module.py` with `exec_module` and never registers it in `sys.modules`, so its top level re-executes on every dispatch and a flag there would reset. `deprecation.py` is imported normally and executes once per process.
- **The call is in `ScriptAutomation.__init__`, not `_run()`,** so all eight dispatch targets are covered (`run`, `docker`, `test`, `experiment`, `remote_run`, `help`, `doc`, `lint`). `_run()`'s `if not recursion:` idiom would only cover `run`.
- **It uses `compare_versions` from `automation/utils.py`, not `mlc.utils.compare_versions`.** The latter calls `version.parse()` without importing `packaging.version` in every released mlcflow, so it raises on exactly the old versions being targeted. The bug would be fixed on going to be released version of mlcflow. But we expect some of the users to use the previous version, so for now, changes in automation/utils.py seems fine

Everything is wrapped so any failure degrades to silence — a notice must never break a run.

## 2. Contributor signal

- `automation/README.md` — records where each file went and that engine changes belong in a PR against mlcflow.
- `.github/workflows/automation-frozen-notice.yml` — posts a sticky comment on PRs touching `automation/`.

The workflow **warns, never blocks**; fixes aimed at the fallback copy are still legitimate while it ships. It uses `pull_request_target` because fork PRs get a read-only token under `pull_request`, and fork contributors are the audience. It is safe in that mode only because it has **no `actions/checkout`** and never executes PR-authored code.

The 11 existing workflows with `automation/**` path filters are untouched — they still exercise the fallback engine, which is what should keep being tested while it ships.

## Verification

Tested against a real `mlcflow==1.2.9` venv with an isolated `MLC_REPOS`:

| Check | Result |
|---|---|
| `mlcr detect,os` | notice shown, exit 0 |
| `mlcr get,generic-python-lib,_package.wheel` | **1** notice across **4** script dispatches |
| `mlc lint script` / `mlc doc script` | 1 notice each, exit 0 |
| `mlcr detect,os -s` (silent) | 1 notice — survives WARNING level |

Also confirmed: forcing `get_mlcflow_version()` to raise still exits 0 with no traceback and no notice, and both files are `autopep8 -a` clean so `format.yml` will not rewrite the commit.

## Note for reviewers

The CI notice cannot fire until it is on `main`, since `pull_request_target` runs the base branch's copy of the workflow. Worth confirming on a throwaway PR after merge that the comment appears, updates in place on a second push rather than duplicating, and the check stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)