### PR TITLE
Remove legacy min_mlc_version key from Cognata dataset script

### DIFF
--- a/script/get-dataset-cognata-mlcommons/meta.yaml
+++ b/script/get-dataset-cognata-mlcommons/meta.yaml
@@ -16,7 +16,6 @@ tags:
 - ml-task--object-detection
 - ml-task--image-segmentation
 private: true
-min_mlc_version: 2.2.0
 
 # Cache
 cache: false


### PR DESCRIPTION
## Summary
- Removes the stale `min_mlc_version: 2.2.0` key from `script/get-dataset-cognata-mlcommons/meta.yaml`.

## Why
This key was a leftover from when the legacy `min_mlc_version` check was silently broken (looked up a nonexistent `"mlc"` distribution + wrong `compare_versions` call signature) and therefore never actually enforced. mlcflow 1.3.0's bundled engine fixed both bugs, which meant the requirement started being enforced for real — and being unsatisfiable (mlcflow is at 1.3.0, not 2.2.0), it hard-blocked this script for every user on 1.3.0+.

The `min_mlc_version` mechanism itself is being removed from mlcflow in favor of `mlc_compat` (mlcommons/mlcflow#286), so this key is now entirely meaningless — dropping it here unblocks the script.

Note: this PR does **not** touch this repo's frozen `automation/` engine copy — per `automation/README.md`, that copy is deprecated and edits there don't reach anyone running a current mlcflow.

## Test plan
- [x] `meta.yaml` parses cleanly with `yaml.safe_load`
- [x] Repo-wide grep confirms `get-dataset-cognata-mlcommons` was the only script using `min_mlc_version`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>