### PR TITLE
Add --download_parallelism input for the R2 downloader (don't merge without merging PR #28)

### DIFF
--- a/script/download-and-extract/README.md
+++ b/script/download-and-extract/README.md
@@ -40,6 +40,7 @@ mlcr download-and-extract file
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--download_path` |  |  | `` |
 | `--extra_folder` |  |  | `` |
 | `--extract_path` |  |  | `` |

--- a/script/download-and-extract/meta.yaml
+++ b/script/download-and-extract/meta.yaml
@@ -28,6 +28,7 @@ new_state_keys: []
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   download_path: MLC_DOWNLOAD_PATH
   extra_folder: MLC_EXTRACT_TO_FOLDER
   extract_path: MLC_EXTRACT_PATH
@@ -36,7 +37,9 @@ input_mapping:
   store: MLC_DOWNLOAD_PATH
   to: MLC_EXTRACT_PATH
   url: MLC_DAE_URL
-input_description: {}
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 deps: []

--- a/script/download-file/README.md
+++ b/script/download-file/README.md
@@ -40,6 +40,7 @@ mlcr download file
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--download_path` |  |  | `` |
 | `--from` |  |  | `` |
 | `--local_path` | Alias for from |  | `` |

--- a/script/download-file/customize.py
+++ b/script/download-file/customize.py
@@ -147,6 +147,13 @@ def preprocess(i):
 
         extra_download_options = env.get('MLC_DOWNLOAD_EXTRA_OPTIONS', '')
 
+        download_parallelism = str(
+            env.get('MLC_DOWNLOAD_PARALLELISM', '')).strip()
+        if download_parallelism and tool != "r2-downloader":
+            logger.warning(
+                f"Ignoring --download_parallelism={download_parallelism}: "
+                f"parallel downloads are only supported by the r2-downloader tool, not '{tool}'")
+
         verify_ssl = is_true(env.get('MLC_VERIFY_SSL', "True"))
         if not verify_ssl or os_info['platform'] == 'windows':
             verify_ssl = False
@@ -309,6 +316,15 @@ def preprocess(i):
         elif tool == "r2-downloader":
             if is_true(env.get('MLC_AUTH_USING_SERVICE_ACCOUNT')):
                 extra_download_options += " -s "
+            # Number of files fetched concurrently. Only forwarded when the user
+            # asked for it, so that the downloader keeps its own default (1 job
+            # for datasets below its file-count threshold, 4 above it).
+            if download_parallelism:
+                if not download_parallelism.isdigit() or int(
+                        download_parallelism) < 1:
+                    return {'return': 1,
+                            'error': f"download_parallelism must be a positive integer, got '{download_parallelism}'"}
+                extra_download_options += f" -j {download_parallelism} "
             env['MLC_DOWNLOAD_CMD'] = f"bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) "
             if env["MLC_HOST_OS_TYPE"] == "windows":
                 # have to modify the variable from url to temp_url if it is

--- a/script/download-file/meta.yaml
+++ b/script/download-file/meta.yaml
@@ -28,6 +28,7 @@ new_state_keys: []
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   download_path: MLC_DOWNLOAD_PATH
   from: MLC_DOWNLOAD_LOCAL_FILE_PATH
   local_path: MLC_DOWNLOAD_LOCAL_FILE_PATH
@@ -35,7 +36,9 @@ input_mapping:
   output_file: MLC_DOWNLOAD_FILENAME
   store: MLC_DOWNLOAD_PATH
   url: MLC_DOWNLOAD_URL
-input_description: {}
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 deps:

--- a/script/get-dataset-cnndm/README.md
+++ b/script/get-dataset-cnndm/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,gpt-j,cnndm,cnn-dailymail,original
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-cnndm/meta.yaml
+++ b/script/get-dataset-cnndm/meta.yaml
@@ -22,6 +22,13 @@ default_env:
 env:
   MLC_DATASET: CNNDM
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Dependencies
 deps:
 - tags: get,sys-utils-mlc

--- a/script/get-dataset-mlperf-inference-dlrmv3-synthetic-streaming/README.md
+++ b/script/get-dataset-mlperf-inference-dlrmv3-synthetic-streaming/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,mlperf,inference,dlrmv3,synthetic-streaming,get-dataset-mlperf-inference-dlrmv3-synthetic-streaming
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-mlperf-inference-dlrmv3-synthetic-streaming/meta.yaml
+++ b/script/get-dataset-mlperf-inference-dlrmv3-synthetic-streaming/meta.yaml
@@ -21,6 +21,13 @@ new_env_keys:
 - MLC_ML_DATASET_MLPERF_INFERENCE_DLRMV3_SYNTHETIC_STREAMING_PATH
 - MLC_ML_DATASET_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-dataset-mlperf-inference-gpt-oss/README.md
+++ b/script/get-dataset-mlperf-inference-gpt-oss/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-dataset-mlperf-inference-gpt-oss
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-mlperf-inference-gpt-oss/meta.yaml
+++ b/script/get-dataset-mlperf-inference-gpt-oss/meta.yaml
@@ -15,6 +15,13 @@ new_env_keys:
 - MLC_ML_DATASET_MLPERF_INFERENCE_GPT_OSS_PATH
 - MLC_ML_DATASET_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-dataset-mlperf-inference-llama3/README.md
+++ b/script/get-dataset-mlperf-inference-llama3/README.md
@@ -40,6 +40,7 @@ mlcr get,dataset,mlperf,llama3,inference
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--outdirname` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-dataset-mlperf-inference-llama3/meta.yaml
+++ b/script/get-dataset-mlperf-inference-llama3/meta.yaml
@@ -20,7 +20,11 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   outdirname: MLC_OUTDIRNAME
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-dataset-mlperf-inference-mixtral/README.md
+++ b/script/get-dataset-mlperf-inference-mixtral/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset-mixtral,openorca-mbxp-gsm8k-combined
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-mlperf-inference-mixtral/meta.yaml
+++ b/script/get-dataset-mlperf-inference-mixtral/meta.yaml
@@ -17,6 +17,13 @@ cache: true
 new_env_keys:
 - MLC_DATASET_*
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Dependencies
 prehook_deps:
 - env:

--- a/script/get-dataset-mlperf-inference-mixtral/meta.yaml
+++ b/script/get-dataset-mlperf-inference-mixtral/meta.yaml
@@ -43,7 +43,7 @@ prehook_deps:
 variations:
   calibration:
     group: dataset-type
-    adr:
+    ad:
       download-file-mixtral-dataset:
         extra_cache_tags: mixtral,get-mixtral-dataset,calibration
     env:
@@ -52,7 +52,7 @@ variations:
   validation:
     default: true
     group: dataset-type
-    adr:
+    ad:
       download-file-mixtral-dataset:
         extra_cache_tags: mixtral,get-mixtral-dataset,validation
     env:
@@ -67,14 +67,14 @@ variations:
   r2-downloader:
     group: download-tool
     default: true
-    adr:
+    ad:
       download-file-mixtral-dataset:
         tags: _r2-downloader
     env:
       MLC_DOWNLOAD_TOOL: r2-downloader
   rclone:
     group: download-tool
-    adr:
+    ad:
       download-file-mixtral-dataset:
         tags: _rclone
     env:
@@ -82,7 +82,7 @@ variations:
       MLC_RCLONE_COPY_USING: copyurl
   wget:
     group: download-tool
-    adr:
+    ad:
       download-file-mixtral-dataset:
         tags: _wget
     env:

--- a/script/get-dataset-mlperf-inference-shopify-catalogue/README.md
+++ b/script/get-dataset-mlperf-inference-shopify-catalogue/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-dataset-mlperf-inference-shopify-catalogue
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-mlperf-inference-shopify-catalogue/meta.yaml
+++ b/script/get-dataset-mlperf-inference-shopify-catalogue/meta.yaml
@@ -15,6 +15,13 @@ new_env_keys:
 - MLC_ML_DATASET_MLPERF_INFERENCE_SHOPIFY_CATALOGUE_DATASET_PATH
 - MLC_ML_DATASET_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-dataset-mlperf-inference-text-to-video/README.md
+++ b/script/get-dataset-mlperf-inference-text-to-video/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-dataset-mlperf-inference-text-to-video
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-mlperf-inference-text-to-video/meta.yaml
+++ b/script/get-dataset-mlperf-inference-text-to-video/meta.yaml
@@ -15,6 +15,13 @@ new_env_keys:
 - MLC_ML_DATASET_MLPERF_INFERENCE_TEXT_TO_VIDEO_DATASET_PATH
 - MLC_ML_DATASET_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-dataset-mlperf-inference-yolo-coco2017-filtered-dataset/README.md
+++ b/script/get-dataset-mlperf-inference-yolo-coco2017-filtered-dataset/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,mlperf-inference,yolo-coco2017-filtered,get-dataset-mlperf-inference-yolo-coco2017-filtered-dataset
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-mlperf-inference-yolo-coco2017-filtered-dataset/meta.yaml
+++ b/script/get-dataset-mlperf-inference-yolo-coco2017-filtered-dataset/meta.yaml
@@ -20,6 +20,13 @@ new_env_keys:
 - MLC_ML_DATASET_MLPERF_INFERENCE_YOLO_COCO2017_FILTERED_DATASET_ANNOTATION_PATH
 - MLC_ML_DATASET_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-dataset-waymo-calibration/README.md
+++ b/script/get-dataset-waymo-calibration/README.md
@@ -40,6 +40,7 @@ mlcr get,waymo,dataset,calibration
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--waymo_calibration_path` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-dataset-waymo-calibration/meta.yaml
+++ b/script/get-dataset-waymo-calibration/meta.yaml
@@ -19,7 +19,11 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   waymo_calibration_path: MLC_DATASET_WAYMO_CALIBRATION_PATH
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Variations
 variations:

--- a/script/get-dataset-waymo-calibration/meta.yaml
+++ b/script/get-dataset-waymo-calibration/meta.yaml
@@ -82,7 +82,7 @@ variations:
       MLC_BYPASS_RCLONE_AUTH: true
   dry-run,r2-downloader:
     env:
-      MLC_DOWNLOAD_EXTRA_OPTIONS: --dry-run
+      MLC_DOWNLOAD_EXTRA_OPTIONS: -x
   dry-run,rclone:
     env:
       MLC_DOWNLOAD_EXTRA_OPTIONS: --dry-run

--- a/script/get-dataset-waymo/README.md
+++ b/script/get-dataset-waymo/README.md
@@ -40,6 +40,7 @@ mlcr get,dataset,waymo
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--waymo_path` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-dataset-waymo/meta.yaml
+++ b/script/get-dataset-waymo/meta.yaml
@@ -18,7 +18,11 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   waymo_path: MLC_DATASET_WAYMO_PATH
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Variations
 variations:

--- a/script/get-dataset-whisper/README.md
+++ b/script/get-dataset-whisper/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-dataset-whisper,get,dataset,whisper
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-dataset-whisper/meta.yaml
+++ b/script/get-dataset-whisper/meta.yaml
@@ -17,6 +17,13 @@ cache: true
 new_env_keys:
 - MLC_DATASET_WHISPER_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   preprocessed:

--- a/script/get-ml-model-abtf-ssd-pytorch/README.md
+++ b/script/get-ml-model-abtf-ssd-pytorch/README.md
@@ -40,6 +40,7 @@ mlcr get,ml-model,abtf-ssd-pytorch,ssd,resnet50,cmc
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--model_code_git_branch` |  |  | `cognata` |
 | `--model_code_git_url` |  |  | `https://github.com/mlcommons/abtf-ssd-pytorch` |
 ### Generic Script Inputs

--- a/script/get-ml-model-abtf-ssd-pytorch/meta.yaml
+++ b/script/get-ml-model-abtf-ssd-pytorch/meta.yaml
@@ -26,8 +26,12 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   model_code_git_branch: MLC_ABTF_MODEL_CODE_GIT_BRANCH
   model_code_git_url: MLC_ABTF_MODEL_CODE_GIT_URL
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 deps:

--- a/script/get-ml-model-deeplabv3_plus/README.md
+++ b/script/get-ml-model-deeplabv3_plus/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,ml-model,deeplab,v3-plus,deeplabv3-plus
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-ml-model-deeplabv3_plus/meta.yaml
+++ b/script/get-ml-model-deeplabv3_plus/meta.yaml
@@ -19,6 +19,13 @@ new_env_keys:
 - MLC_ML_MODEL_DEEPLABV3_PLUS_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-ml-model-deepseek-r1/README.md
+++ b/script/get-ml-model-deepseek-r1/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,ml-model,deepseek-r1,get-ml-model-deepseek-r1
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-ml-model-deepseek-r1/meta.yaml
+++ b/script/get-ml-model-deepseek-r1/meta.yaml
@@ -18,6 +18,13 @@ new_env_keys:
 - MLC_ML_MODEL_DEEPSEEK_R1_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-ml-model-dlrm-terabyte/README.md
+++ b/script/get-ml-model-dlrm-terabyte/README.md
@@ -40,6 +40,7 @@ mlcr get,ml-model,dlrm,raw,terabyte,criteo-terabyte,criteo,recommendation
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--dir` |  |  | `` |
 | `--download_path` | Alias for dir |  | `` |
 | `--to` | Alias for dir |  | `` |

--- a/script/get-ml-model-dlrm-terabyte/meta.yaml
+++ b/script/get-ml-model-dlrm-terabyte/meta.yaml
@@ -32,8 +32,12 @@ new_env_keys:
 # Input mapping
 input_mapping:
   dir: MLC_DOWNLOAD_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   download_path: MLC_DOWNLOAD_PATH
   to: MLC_DOWNLOAD_PATH
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-dlrm-v3/README.md
+++ b/script/get-ml-model-dlrm-v3/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,ml-model,dlrm-v3,get-ml-model-dlrm-v3
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-ml-model-dlrm-v3/meta.yaml
+++ b/script/get-ml-model-dlrm-v3/meta.yaml
@@ -18,6 +18,13 @@ new_env_keys:
 - MLC_ML_MODEL_DLRM_V3_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-ml-model-gpt-oss/README.md
+++ b/script/get-ml-model-gpt-oss/README.md
@@ -40,6 +40,7 @@ mlcr get-ml-model-gpt-oss
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--checkpoint` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-ml-model-gpt-oss/meta.yaml
+++ b/script/get-ml-model-gpt-oss/meta.yaml
@@ -18,6 +18,10 @@ new_env_keys:
 # Input mapping
 input_mapping:
   checkpoint: MLC_ML_MODEL_GPT_OSS_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-gptj/README.md
+++ b/script/get-ml-model-gptj/README.md
@@ -40,6 +40,7 @@ mlcr get,raw,ml-model,gptj,gpt-j,large-language-model
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--checkpoint` |  |  | `` |
 | `--download_path` |  |  | `` |
 | `--to` | Alias for download_path |  | `` |

--- a/script/get-ml-model-gptj/meta.yaml
+++ b/script/get-ml-model-gptj/meta.yaml
@@ -28,8 +28,12 @@ new_env_keys:
 # Input mapping
 input_mapping:
   checkpoint: GPTJ_CHECKPOINT_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   download_path: MLC_DOWNLOAD_PATH
   to: MLC_DOWNLOAD_PATH
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-llama2/README.md
+++ b/script/get-ml-model-llama2/README.md
@@ -40,6 +40,7 @@ mlcr get,raw,ml-model,language-processing,llama2,llama2-70b,text-summarization
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--checkpoint` |  |  | `` |
 | `--client_id` |  |  | `` |
 | `--client_secret` |  |  | `` |

--- a/script/get-ml-model-llama2/meta.yaml
+++ b/script/get-ml-model-llama2/meta.yaml
@@ -33,7 +33,11 @@ input_mapping:
   checkpoint: LLAMA2_CHECKPOINT_PATH
   client_id: CF_ACCESS_CLIENT_ID
   client_secret: CF_ACCESS_CLIENT_SECRET
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-llama3/README.md
+++ b/script/get-ml-model-llama3/README.md
@@ -40,6 +40,7 @@ mlcr get,raw,ml-model,language-processing,llama3,llama3-405b
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--outdirname` |  |  | `` |
 ### Generic Script Inputs
 
@@ -71,7 +72,6 @@ mlcr get,raw,ml-model,language-processing,llama3,llama3-405b
 ### Download-tool
 
 - `r2-downloader` (default)
-- `rclone`
 
 ### Framework
 

--- a/script/get-ml-model-llama3/meta.yaml
+++ b/script/get-ml-model-llama3/meta.yaml
@@ -23,7 +23,11 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   outdirname: MLC_OUTDIRNAME
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-mixtral/README.md
+++ b/script/get-ml-model-mixtral/README.md
@@ -40,6 +40,7 @@ mlcr get,raw,ml-model,language-processing,mixtral,mixtral-8x7b
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--checkpoint` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-ml-model-mixtral/meta.yaml
+++ b/script/get-ml-model-mixtral/meta.yaml
@@ -27,6 +27,10 @@ new_env_keys:
 # Input mapping
 input_mapping:
   checkpoint: MIXTRAL_CHECKPOINT_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-pointpainting/README.md
+++ b/script/get-ml-model-pointpainting/README.md
@@ -40,6 +40,7 @@ mlcr get,ml-model,ml,model,pointpainting
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--dp_resnet50_path` |  |  | `` |
 | `--pp_path` |  |  | `` |
 ### Generic Script Inputs

--- a/script/get-ml-model-pointpainting/meta.yaml
+++ b/script/get-ml-model-pointpainting/meta.yaml
@@ -21,8 +21,12 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   dp_resnet50_path: MLC_ML_MODEL_DPLAB_RESNET50_PATH
   pp_path: MLC_ML_MODEL_POINT_PAINTING_PATH
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Variations
 variations:

--- a/script/get-ml-model-qwen3-vlm/README.md
+++ b/script/get-ml-model-qwen3-vlm/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-ml-model-qwen3-vl
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-ml-model-qwen3-vlm/meta.yaml
+++ b/script/get-ml-model-qwen3-vlm/meta.yaml
@@ -15,6 +15,13 @@ new_env_keys:
 - MLC_ML_MODEL_QWEN3_VLM_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-ml-model-rgat/README.md
+++ b/script/get-ml-model-rgat/README.md
@@ -40,6 +40,7 @@ mlcr get,raw,ml-model,rgat
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--checkpoint` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-ml-model-rgat/meta.yaml
+++ b/script/get-ml-model-rgat/meta.yaml
@@ -25,6 +25,10 @@ new_env_keys:
 # Input mapping
 input_mapping:
   checkpoint: RGAT_CHECKPOINT_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-stable-diffusion/README.md
+++ b/script/get-ml-model-stable-diffusion/README.md
@@ -40,6 +40,7 @@ mlcr get,raw,ml-model,stable-diffusion,sdxl,text-to-image
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--checkpoint` |  |  | `` |
 | `--download_path` |  |  | `` |
 | `--to` | Alias for download_path |  | `` |

--- a/script/get-ml-model-stable-diffusion/meta.yaml
+++ b/script/get-ml-model-stable-diffusion/meta.yaml
@@ -28,8 +28,12 @@ new_env_keys:
 # Input mapping
 input_mapping:
   checkpoint: SDXL_CHECKPOINT_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   download_path: MLC_DOWNLOAD_PATH
   to: MLC_DOWNLOAD_PATH
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-wan2/README.md
+++ b/script/get-ml-model-wan2/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-ml-model-wan2
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-ml-model-wan2/meta.yaml
+++ b/script/get-ml-model-wan2/meta.yaml
@@ -15,6 +15,13 @@ new_env_keys:
 - MLC_ML_MODEL_WAN2_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-ml-model-whisper/README.md
+++ b/script/get-ml-model-whisper/README.md
@@ -40,6 +40,7 @@ mlcr get-ml-model-whisper,get,ml-model,whisper,speech-recognition
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--checkpoint` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-ml-model-whisper/meta.yaml
+++ b/script/get-ml-model-whisper/meta.yaml
@@ -26,6 +26,10 @@ new_env_keys:
 # Input mapping
 input_mapping:
   checkpoint: MLC_ML_MODEL_WHISPER_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 prehook_deps:

--- a/script/get-ml-model-yolov11/README.md
+++ b/script/get-ml-model-yolov11/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-ml-model-yolov11
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-ml-model-yolov11/meta.yaml
+++ b/script/get-ml-model-yolov11/meta.yaml
@@ -15,6 +15,13 @@ new_env_keys:
 - MLC_ML_MODEL_YOLOV11_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   mlc:

--- a/script/get-preprocessed-dataset-cognata/README.md
+++ b/script/get-preprocessed-dataset-cognata/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,cognata,preprocessed
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-preprocessed-dataset-cognata/meta.yaml
+++ b/script/get-preprocessed-dataset-cognata/meta.yaml
@@ -20,6 +20,13 @@ default_env:
 new_env_keys:
 - MLC_PREPROCESSED_DATASET_*
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   prebuilt:

--- a/script/get-preprocessed-dataset-criteo/README.md
+++ b/script/get-preprocessed-dataset-criteo/README.md
@@ -40,6 +40,7 @@ mlcr get,dataset,criteo,recommendation,dlrm,preprocessed
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--dir` |  |  | `` |
 | `--output_dir` |  |  | `` |
 | `--threads` |  |  | `` |

--- a/script/get-preprocessed-dataset-criteo/meta.yaml
+++ b/script/get-preprocessed-dataset-criteo/meta.yaml
@@ -25,8 +25,12 @@ new_env_keys:
 # Input mapping
 input_mapping:
   dir: MLC_DATASET_PREPROCESSED_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   output_dir: MLC_DATASET_PREPROCESSED_OUTPUT_PATH
   threads: MLC_NUM_PREPROCESS_THREADS
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 deps:

--- a/script/get-preprocessed-dataset-mlperf-deepseek-r1/README.md
+++ b/script/get-preprocessed-dataset-mlperf-deepseek-r1/README.md
@@ -40,6 +40,7 @@ mlcr get,preprocessed,dataset,mlperf,deepseek-r1,mlperf-deepseek-r1
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--deepseek_path` |  |  | `` |
 ### Generic Script Inputs
 

--- a/script/get-preprocessed-dataset-mlperf-deepseek-r1/meta.yaml
+++ b/script/get-preprocessed-dataset-mlperf-deepseek-r1/meta.yaml
@@ -24,6 +24,10 @@ new_env_keys:
 # Input mapping
 input_mapping:
   deepseek_path: MLC_PREPROCESSED_DATASET_DEEPSEEK_R1_PATH
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Variations
 variations:

--- a/script/get-preprocessed-dataset-nuscenes/README.md
+++ b/script/get-preprocessed-dataset-nuscenes/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,nuscenes,preprocessed
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-preprocessed-dataset-nuscenes/meta.yaml
+++ b/script/get-preprocessed-dataset-nuscenes/meta.yaml
@@ -20,6 +20,13 @@ default_env:
 new_env_keys:
 - MLC_PREPROCESSED_DATASET_*
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Variations
 variations:
   prebuilt:

--- a/script/get-preprocessed-dataset-openorca/README.md
+++ b/script/get-preprocessed-dataset-openorca/README.md
@@ -36,7 +36,11 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,openorca,language-processing,preprocessed
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |

--- a/script/get-preprocessed-dataset-openorca/meta.yaml
+++ b/script/get-preprocessed-dataset-openorca/meta.yaml
@@ -22,6 +22,13 @@ default_env:
 env:
   MLC_DATASET: OPENORCA
 
+# Input mapping
+input_mapping:
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
+
 # Dependencies
 deps:
 - tags: get,sys-utils-mlc

--- a/script/run-mlperf-automotive-app/README.md
+++ b/script/run-mlperf-automotive-app/README.md
@@ -40,6 +40,7 @@ mlcr run-abtf,inference
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--backend` |  |  | `` |
 | `--batch_size` |  |  | `` |
 | `--category` |  |  | `` |

--- a/script/run-mlperf-automotive-app/meta.yaml
+++ b/script/run-mlperf-automotive-app/meta.yaml
@@ -44,6 +44,7 @@ input_mapping:
   device: MLC_MLPERF_DEVICE
   division: MLC_MLPERF_SUBMISSION_DIVISION
   docker: MLC_MLPERF_USE_DOCKER
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   dump_version_info: MLC_DUMP_VERSION_INFO
   execution_mode: MLC_MLPERF_RUN_STYLE
   find_performance: MLC_MLPERF_FIND_PERFORMANCE_MODE
@@ -94,6 +95,9 @@ input_mapping:
   target_qps: MLC_MLPERF_LOADGEN_TARGET_QPS
   test_query_count: MLC_TEST_QUERY_COUNT
   threads: MLC_NUM_THREADS
+input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
 
 # Dependencies
 deps:

--- a/script/run-mlperf-inference-app/README.md
+++ b/script/run-mlperf-inference-app/README.md
@@ -56,6 +56,7 @@ mlcr run-mlperf,inference
 | `--power` | Measure power | ['yes', 'no'] | `no` |
 | `--adr.mlperf-power-client.power_server` | MLPerf Power server IP address |  | `192.168.0.15` |
 | `--adr.mlperf-power-client.port` | MLPerf Power server port |  | `4950` |
+| `--download_parallelism` | Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files. |  | `` |
 | `--results_dir` | Alias for output_dir |  | `` |
 | `--use_dataset_from_host` | Run the dataset download script on the host machine and mount the dataset into the Docker container to avoid repeated downloads. | [True, False] | `no` |
 | `--use_model_from_host` | Run the model download script on the host machine and mount the model files into the Docker container to avoid repeated downloads. | [True, False] | `no` |
@@ -101,6 +102,7 @@ mlcr run-mlperf,inference
 | `--gpu_name` |  |  | `` |
 | `--hw_notes_extra` |  |  | `` |
 | `--imagenet_path` |  |  | `` |
+| `--imagenet_preprocessed_path` |  |  | `` |
 | `--lang` | Alias for implementation |  | `` |
 | `--max_query_count` |  |  | `` |
 | `--max_test_duration` |  |  | `` |
@@ -183,7 +185,8 @@ mlcr run-mlperf,inference
 - `r5.1`
 - `r5.1-dev`
 - `r6.0`
-- `r6.0-dev` (default)
+- `r6.0-dev`
+- `r6.1-dev` (default)
 
 ### Mode
 

--- a/script/run-mlperf-inference-app/meta.yaml
+++ b/script/run-mlperf-inference-app/meta.yaml
@@ -62,6 +62,7 @@ input_mapping:
   dlrm_data_path: DLRM_DATA_PATH
   docker: MLC_MLPERF_USE_DOCKER
   docker_keep_alive: MLC_DOCKER_CONTAINER_KEEP_ALIVE
+  download_parallelism: MLC_DOWNLOAD_PARALLELISM
   dump_version_info: MLC_DUMP_VERSION_INFO
   execution_mode: MLC_MLPERF_RUN_STYLE
   find_performance: MLC_MLPERF_FIND_PERFORMANCE_MODE
@@ -93,6 +94,7 @@ input_mapping:
   output_tar: MLPERF_INFERENCE_SUBMISSION_TAR_FILE
   performance_sample_count: MLC_MLPERF_LOADGEN_PERFORMANCE_SAMPLE_COUNT
   pip_loadgen: MLC_MLPERF_INFERENCE_LOADGEN_INSTALL_FROM_PIP
+  podman_storage_root: MLC_PODMAN_STORAGE_ROOT
   pointpainting_checkpoint_path: MLC_ML_MODEL_POINT_PILLARS_PATH
   power: MLC_SYSTEM_POWER
   precision: MLC_MLPERF_MODEL_PRECISION
@@ -135,8 +137,9 @@ input_mapping:
   vllm_model_name: MLC_VLLM_SERVER_MODEL_NAME
   vllm_tp_size: MLC_MLPERF_INFERENCE_TP_SIZE
   waymo_path: MLC_DATASET_WAYMO_PATH
-  podman_storage_root: MLC_PODMAN_STORAGE_ROOT
 input_description:
+  download_parallelism:
+    desc: Number of files the MLCommons R2 downloader fetches concurrently. Only used with the r2-downloader download tool; when unset the downloader picks the value itself based on the number of files.
   division:
     choices:
     - open


### PR DESCRIPTION
> ## ⚠️ Don't merge without merging PR #28
>
> This depends on [mlcommons/r2-downloader#28](https://github.com/mlcommons/r2-downloader/pull/28).
> `download-file` pins the downloader to `refs/heads/main`, so until #28 lands
> there, passing `--download_parallelism` fails with `illegal option -- j`.
> Harmless while nobody passes the flag, but please don't merge these out of order.

## Summary

[mlcommons/r2-downloader#28](https://github.com/mlcommons/r2-downloader/pull/28) adds a `-j <n>` flag to `mlc-r2-downloader.sh` for fetching dataset files concurrently. This exposes it through MLC as a new input argument, `--download_parallelism`.

## Changes

**`script/download-file/customize.py`** — the consumer. Appends `-j <n>` to the r2-downloader command, but **only when explicitly set**, so the downloader keeps its own auto-detection by default (1 job below its 20-file threshold, 4 above, clamped to the file count). Non-positive-integer values are rejected with an MLC-level error before any dep runs. Passing the flag to a non-r2 tool logs a warning and is ignored, since wget/curl/rclone/gdown have no equivalent option here.

**37 `meta.yaml` files** — `input_mapping` (`download_parallelism` → `MLC_DOWNLOAD_PARALLELISM`) plus an `input_description` entry.

`input_mapping` is applied per-script against the invoked script's own meta — mlcflow overwrites it rather than inheriting it down the dep chain — so every entry point that can reach an r2 download needs its own declaration. The env var then propagates to `download-file` normally. Covered:

- `download-file`, `download-and-extract`
- the 34 `get-*` scripts with an `r2-downloader` variation
- `run-mlperf-inference-app`, `run-mlperf-automotive-app`, so it works from the top-level benchmark flow

Docker needs no extra plumbing: the inner `mlcr` command is regenerated from the input dict, so the flag forwards into the container automatically.

**37 `README.md` files** — regenerated with `mlc doc script <uid>`, the same command CI's `document-scripts.yml` runs.

## Test plan

- [x] End-to-end through a two-level wrapper:
      `mlcr get-ml-model-yolov11,_mlc,_r2-downloader,_dry-run --download_parallelism=6`
      emits `... -d '<path>' -x -j 6 https://yolo.mlcommons-storage.org/...` — the value
      traverses wrapper → `download-and-extract` → `download-file`.
- [x] Without the flag, the generated command is byte-identical to before (no `-j`).
- [x] `--download_parallelism=abc` → `Error : download_parallelism must be a positive integer, got 'abc'`.
- [x] With `_wget`: warns `parallel downloads are only supported by the r2-downloader tool, not 'wget'`, emits no `-j`.
- [x] Ran the #28 branch script directly with the exact flag shape MLC now emits; it reports `PARALLEL_JOBS: 6`.
- [x] `mlc lint script` on all 37 metas — no churn.
- [x] `autopep8 -a` on `customize.py` — flags only pre-existing f-string lines, none added here.

## Note on incidental README changes

Regenerating the READMEs surfaced a few **pre-existing** stale entries, unrelated to this change. CI would have corrected them on the next push, so they're kept here:

- `get-ml-model-llama3` still listed an `rclone` download-tool variation that no longer exists in its meta
- `run-mlperf-inference-app` was missing `--imagenet_preprocessed_path` and still showed `r6.0-dev` as the default benchmark version instead of `r6.1-dev`

`mlc lint script` also moved one out-of-order `podman_storage_root` line into alphabetical position in `run-mlperf-inference-app/meta.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
