### PR TITLE
Build the infrastructure graph from the existing sysinfo fan-out

### DIFF
--- a/script/generate-infograph/COPYRIGHT.md
+++ b/script/generate-infograph/COPYRIGHT.md
@@ -1,0 +1,9 @@
+# Copyright Notice
+
+© 2026-2027 MLCommons. All Rights Reserved.
+
+This file is licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License can be obtained at:
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is provided on an "AS IS" basis, without warranties or conditions of any kind, either express or implied. Please refer to the License for the specific language governing permissions and limitations under the License.

--- a/script/generate-infograph/README.md
+++ b/script/generate-infograph/README.md
@@ -1,4 +1,4 @@
-# README for get-mlperf-multi-node-system-info
+# README for generate-infograph
 This README is automatically generated. Edit [info.md](info.md) to add custom contents. Please follow the [script execution document](https://docs.mlcommons.org/mlcflow/targets/script/execution-flow/) to understand more about the MLC script execution.
 
 `mlcflow` stores all local data under `$HOME/MLC` by default. So, if there is space constraint on the home directory and you have more space on say `/mnt/$USER`, you can do
@@ -33,55 +33,17 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 ## Run Commands
 
 ```bash
-mlcr get-mlperf-multi-node-system-info
+mlcr generate,infograph,infragraph
 ```
 
 ### Script Inputs
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
-| `--config_file` |  |  | `` |
-| `--category` |  |  | `` |
-| `--cooling` |  |  | `` |
-| `--dataset_id` |  |  | `` |
-| `--dataset_name` |  |  | `` |
-| `--dataset_type` |  |  | `` |
-| `--division` |  |  | `` |
-| `--hw_notes` |  |  | `` |
-| `--input_token_average` |  |  | `` |
-| `--link_to_dataset` |  |  | `` |
-| `--link_to_model` |  |  | `` |
-| `--link_to_model_transformation` |  |  | `` |
-| `--model_id` |  |  | `` |
-| `--model_name` |  |  | `` |
-| `--model_notes` |  |  | `` |
-| `--model_precision` |  |  | `` |
-| `--other_hardware` |  |  | `` |
+| `--input_dir` |  |  | `` |
+| `--graph_name` |  |  | `` |
 | `--out_dir_path` |  |  | `` |
-| `--out_file_name` |  |  | `` |
-| `--output_token_average` |  |  | `` |
-| `--skip_ssh_key_file` |  |  | `` |
-| `--ssh_ids` |  |  | `` |
-| `--system_availability_status` |  |  | `` |
-| `--submitter_contact` |  |  | `` |
-| `--submitter_org_name` |  |  | `` |
-| `--node_config_file` |  |  | `` |
-| `--system_name` |  |  | `` |
-| `--container_link` |  |  | `` |
-| `--measured_accuracy_score` |  |  | `` |
-| `--system_node_ensemble_count` |  |  | `` |
-| `--system_node_ensemble_total` |  |  | `` |
-| `--system_size` |  |  | `` |
-| `--serving_framework` |  |  | `` |
-| `--endpoint_url` |  |  | `` |
-| `--serving_node` |  |  | `` |
-| `--log_path` |  |  | `/tmp/serving.log` |
-| `--run_metadata_path` |  |  | `` |
-| `--serving_framework_type` |  |  | `` |
-| `--system_type_detail` |  |  | `` |
-| `--redfish_endpoint` |  |  | `` |
-| `--redfish_username` |  |  | `` |
-| `--redfish_password` |  |  | `` |
+| `--out_file_name` |  |  | `infragraph.json` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -104,23 +66,6 @@ mlcr get-mlperf-multi-node-system-info
 | `--verify_ssl` | Verify SSL |  | `False` |
 ## Variations
 
-### Accelerator-backend
-
-- `cuda`
-- `rocm`
-- `xpu`
-
-### Mlperf-benchmark
-
-- `endpoints`
-- `inference`
-
 ### Ungrouped
 
-- `exclude_current_node`
-- `inference_optional_nameplate`
-- `infragraph`
-- `network`
 - `no_visualize`
-- `power`
-- `redfish`

--- a/script/generate-infograph/build_infragraph.py
+++ b/script/generate-infograph/build_infragraph.py
@@ -1,0 +1,365 @@
+"""Build one infrastructure graph out of a directory of per-node captures.
+
+The directory is whatever `get-mlperf-multi-node-system-info,_infragraph`
+leaves behind: for every node, an hwloc topology and the sysinfo JSON that
+shares its stem.
+
+    mlperf-system-info-single-node-0.lstopo.xml
+    mlperf-system-info-single-node-0.json
+    mlperf-system-info-single-node-1.lstopo.xml
+    mlperf-system-info-single-node-1.json
+
+Each topology is translated to an infragraph device definition, the
+definitions are unioned into a single `Infrastructure`, and each node's cpu /
+xpu graph nodes are annotated from that node's sysinfo. One node in equals a
+single-node graph; N nodes in equals a multi-node graph -- the path through
+this script is the same either way.
+
+Structurally identical devices are emitted once and instantiated per node, so
+a homogeneous cluster yields one device definition rather than N copies of it.
+Instances are named after each node's real hostname, which is what puts the
+node identity into generated graph node names (`mlc2.0.cpu.0`) and lets each
+node be annotated with its own sysinfo.
+
+No infrastructure-level `edges` are emitted: lstopo sees one host at a time, so
+there is no observable inter-node fabric to infer. The merged graph is a set of
+per-node subgraphs, not a fabric topology.
+"""
+
+import argparse
+import copy
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import yaml
+from infragraph import *
+from infragraph.infragraph_service import InfraGraphService
+from infragraph.translators.translator_handler import run_translator
+from infragraph.visualizer.visualize import run_visualizer
+
+TOPOLOGY_SUFFIX = ".lstopo.xml"
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input-dir", required=True,
+                   help="Directory holding the per-node *.lstopo.xml topologies "
+                        "and their matching sysinfo JSON files.")
+    p.add_argument("--output", required=True,
+                   help="Path of the annotated infrastructure graph JSON to write.")
+    p.add_argument("--output-yaml", required=True,
+                   help="Path of the merged Infrastructure YAML to write.")
+    p.add_argument("--name", default="multi-node-system",
+                   help="Name of the merged infrastructure.")
+    p.add_argument("--visuals-dir", default="",
+                   help="Directory to write the visualizer bundle into. "
+                        "Empty to skip visualization.")
+    return p.parse_args()
+
+
+def sort_key(stem):
+    """Natural sort: trailing digits compare numerically, the rest lexically.
+
+    Keeps node-2 ahead of node-10 in the instance list, so the graph reads
+    against the same node numbering the submission uses. Mirrors _sort_key in
+    customize.py -- the two must agree or the node count logged in preprocess
+    describes a different set than the one merged here.
+    """
+    head = stem.rstrip("0123456789")
+    tail = stem[len(head):]
+    return (head, int(tail) if tail else -1)
+
+
+def discover_nodes(input_dir):
+    """[(stem, xml_path, sysinfo_path_or_None)] for every topology in the dir."""
+    nodes = []
+    for xml in sorted(input_dir.glob("*" + TOPOLOGY_SUFFIX)):
+        stem = xml.name[:-len(TOPOLOGY_SUFFIX)]
+        sysinfo = input_dir / (stem + ".json")
+        nodes.append((stem, xml, sysinfo if sysinfo.is_file() else None))
+    return sorted(nodes, key=lambda n: sort_key(n[0]))
+
+
+def build_type_query(*node_types):
+    """One attribute query carrying a named node_filter per component type."""
+    request = QueryRequest()
+    for node_type in node_types:
+        node_filter = request.attribute_query.node_filters.add(
+            name=f"{node_type} filter")
+        node_filter.attribute_filters.attributes.add(
+            attribute="type", value=node_type)
+    return request
+
+
+def matched_nodes(response, node_type):
+    """Nodes matched by the `<node_type> filter`. attribute_filters matching is
+    substring based, so keep only the exact `type` hits."""
+    for result in response.attribute_query.nodes:
+        if result.name != f"{node_type} filter":
+            continue
+        return [node for node in result.nodes
+                if any(a.attribute == "type" and a.value == node_type
+                       for a in node.attributes)]
+    return []
+
+
+def unique_name(base, taken):
+    """Return `base` if free, else `base-2`, `base-3`, ... ."""
+    if base not in taken:
+        return base
+    suffix = 2
+    while f"{base}-{suffix}" in taken:
+        suffix += 1
+    return f"{base}-{suffix}"
+
+
+def sanitize_instance_name(name):
+    """Make `name` safe to use as an infragraph instance name.
+
+    Generated graph node names are "<instance>.<idx>.<component>.<idx>" and
+    infragraph recovers the instance by splitting on '.', so a dot inside the
+    instance name would corrupt node addressing. An FQDN such as
+    `node1.cluster.local` therefore becomes `node1-cluster-local`. Whitespace is
+    collapsed for the same reason it is avoided elsewhere: these names end up in
+    shell output and in query filters.
+    """
+    return "-".join(str(name).split()).replace(".", "-")
+
+
+def node_display_name(xml_path, stem):
+    """The node's real hostname, read from its lstopo XML.
+
+    lstopo records the host it ran on as a single
+    `<info name="HostName" value="..."/>` element, so the hostname costs no
+    extra remote work -- the XML is already here. Falls back to the file stem
+    when the element is missing (lstopo omits HostName on some platforms) so
+    naming never hard-fails.
+    """
+    try:
+        tree = ET.parse(xml_path)
+    except ET.ParseError as e:
+        print(f"[WARN] {stem}: could not parse {xml_path} for a hostname "
+              f"({e}); falling back to {stem}.", file=sys.stderr)
+        return sanitize_instance_name(stem)
+
+    for info in tree.iter("info"):
+        if info.get("name") == "HostName":
+            value = (info.get("value") or "").strip()
+            if value:
+                return sanitize_instance_name(value)
+
+    print(f"[WARN] {stem}: no HostName in {xml_path}; falling back to {stem}.",
+          file=sys.stderr)
+    return sanitize_instance_name(stem)
+
+
+def translate_nodes(nodes, work_dir):
+    """Run the lstopo translator over every node. Returns [(stem, dev_dict)]."""
+    translated = []
+    for stem, xml_path, _sysinfo in nodes:
+        dev_path = work_dir / f"dev-{stem}.yaml"
+        run_translator("lstopo", str(xml_path), str(dev_path), "yaml", None)
+        if not dev_path.is_file():
+            print(f"[ERROR] {stem}: `infragraph translate lstopo` produced no "
+                  f"output at {dev_path}.", file=sys.stderr)
+            sys.exit(1)
+        with open(dev_path, "r", encoding="utf-8") as f:
+            translated.append((stem, yaml.safe_load(f) or {}))
+        print(f"[INFO] {stem}: topology translated to {dev_path}")
+    return translated
+
+
+def merge_devices(translated, display_names):
+    """Build the merged Infrastructure dict and the stem -> instance map."""
+    devices = {}           # device name -> device dict
+    instance_of_node = {}  # stem -> instance name
+    device_of_node = {}    # stem -> device name
+
+    for stem, per_node in translated:
+        node_devices = per_node.get("devices") or []
+        if len(node_devices) != 1:
+            print(f"[ERROR] {stem}: translated topology declares "
+                  f"{len(node_devices)} devices; expected exactly 1 from "
+                  "`infragraph translate lstopo`.", file=sys.stderr)
+            sys.exit(1)
+
+        device = copy.deepcopy(node_devices[0])
+        original_name = device.get("name") or stem
+
+        # Reuse an existing device definition when this node is structurally
+        # identical to one already merged -- the homogeneous-cluster case.
+        # Compare with the name masked out so a renamed-but-identical device
+        # still dedupes.
+        reused = None
+        probe = dict(device, name=None)
+        for existing_name, existing in devices.items():
+            if dict(existing, name=None) == probe:
+                reused = existing_name
+                break
+
+        if reused is None:
+            device_name = unique_name(original_name, devices)
+            device["name"] = device_name
+            devices[device_name] = device
+        else:
+            device_name = reused
+
+        # Two nodes can legitimately report the same hostname (cloned images, a
+        # misconfigured cluster) and duplicate instance names would silently
+        # collapse two nodes into one, so uniqueness is enforced here.
+        instance_name = unique_name(
+            display_names[stem], set(instance_of_node.values()))
+        instance_of_node[stem] = instance_name
+        device_of_node[stem] = device_name
+
+    merged = {
+        "devices": list(devices.values()),
+        "instances": [
+            {
+                "name": instance_of_node[stem],
+                "device": device_of_node[stem],
+                "count": 1,
+                # Keep the stem in the description: it is the only link back to
+                # that node's sysinfo JSON once the instance has been renamed
+                # to the hostname.
+                "description": stem,
+            }
+            for stem, _ in translated
+        ],
+    }
+    return merged, instance_of_node
+
+
+def load_sysinfo(sysinfo_path, stem):
+    """Load a node's sysinfo JSON. Returns {} when it is absent or unreadable."""
+    if sysinfo_path is None:
+        print(f"[WARN] {stem}: no matching sysinfo JSON; that node's topology "
+              "will be emitted unannotated.", file=sys.stderr)
+        return {}
+    try:
+        with open(sysinfo_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"[WARN] {stem}: could not read {sysinfo_path} ({e}); that "
+              "node's topology will be emitted unannotated.", file=sys.stderr)
+        return {}
+
+
+def annotate(service, nodes, instance_of_node):
+    """Attach each node's sysinfo to that node's cpu / xpu graph nodes."""
+    response = service.query_graph(build_type_query("cpu", "xpu"))
+    cpu_matches = matched_nodes(response, "cpu")
+    xpu_matches = matched_nodes(response, "xpu")
+
+    annotation = Annotation()
+    annotated = 0
+
+    for stem, _xml, sysinfo_path in nodes:
+        sysinfo = load_sysinfo(sysinfo_path, stem)
+        if not sysinfo:
+            continue
+
+        # The single-node sysinfo JSON is a flat dict of prefixed keys; group by
+        # prefix to recover the processor / accelerator attribute sets.
+        processor_attrs = {k: v for k, v in sysinfo.items()
+                           if k.startswith("host_processor")}
+        accelerator_attrs = {k: v for k, v in sysinfo.items()
+                             if k.startswith("accelerator")}
+
+        # Graph node names are "<instance>.<idx>.<component>.<idx>", so the
+        # instance name prefix is what scopes a match to this node.
+        prefix = instance_of_node[stem] + "."
+
+        for match in cpu_matches:
+            if not match.name.startswith(prefix):
+                continue
+            node = annotation.nodes.add(name=match.name)
+            for key, value in processor_attrs.items():
+                node.attributes.add(attribute=key, value=str(value))
+            annotated += 1
+
+        accel_model = accelerator_attrs.get("accelerator_model_name", "")
+        node_xpus = [m for m in xpu_matches if m.name.startswith(prefix)]
+        accel_hits = 0
+        for match in node_xpus:
+            if accel_model and accel_model not in match.name:
+                continue
+            node = annotation.nodes.add(name=match.name)
+            for key, value in accelerator_attrs.items():
+                node.attributes.add(attribute=key, value=str(value))
+            annotated += 1
+            accel_hits += 1
+
+        # lstopo does not always surface the benchmark accelerator as an xpu
+        # component -- a discrete GPU can land under pci_device while the
+        # on-board BMC display controller is what gets typed xpu. Without this
+        # warning the graph looks complete while carrying no accelerator
+        # attributes for the node at all.
+        if accelerator_attrs and not accel_hits:
+            seen = [m.name.split(".", 2)[-1] for m in node_xpus] or "none"
+            print(f"[WARN] {stem}: sysinfo reports accelerator "
+                  f"'{accel_model}' but no xpu component in this node's "
+                  f"topology matches that name (xpu components seen: {seen}). "
+                  "Accelerator attributes were NOT attached for this node.",
+                  file=sys.stderr)
+
+    if annotated:
+        service.annotate_graph(annotation)
+    print(f"[INFO] annotated {annotated} graph node(s) across "
+          f"{len(nodes)} node(s)")
+
+
+def main():
+    args = parse_args()
+
+    input_dir = Path(args.input_dir)
+    nodes = discover_nodes(input_dir)
+    if not nodes:
+        print(f"[ERROR] no *{TOPOLOGY_SUFFIX} topology files in {input_dir}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    output_path = Path(args.output)
+    merged_yaml_path = Path(args.output_yaml)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    merged_yaml_path.parent.mkdir(parents=True, exist_ok=True)
+
+    display_names = {stem: node_display_name(xml, stem)
+                     for stem, xml, _ in nodes}
+
+    # The per-node translations are intermediates; they are kept beside the
+    # merged YAML rather than in a temp dir so a failed merge can be debugged
+    # from what is left on disk.
+    translated = translate_nodes(nodes, merged_yaml_path.parent)
+
+    merged, instance_of_node = merge_devices(translated, display_names)
+    merged["name"] = args.name
+    merged["description"] = (
+        f"Infrastructure graph for {len(nodes)} node(s): "
+        + ", ".join(instance_of_node[stem] for stem, _, _ in nodes))
+
+    with open(merged_yaml_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(merged, f, sort_keys=True)
+    print(f"[INFO] merged Infrastructure YAML written to {merged_yaml_path}")
+
+    service = InfraGraphService()
+    service.set_graph(Infrastructure().deserialize(merged))
+
+    annotate(service, nodes, instance_of_node)
+
+    get_graph_req = GraphRequest()
+    get_graph_req.choice = get_graph_req.INFRAGRAPH
+    get_graph_req.infragraph.annotations.choice = "full"
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(service.get_graph(get_graph_req))
+    print(f"[INFO] infrastructure graph written to {output_path}")
+
+    if args.visuals_dir:
+        print(f"[INFO] generating visualizer bundle in {args.visuals_dir}")
+        run_visualizer(input_file=str(output_path), output=args.visuals_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/generate-infograph/customize.py
+++ b/script/generate-infograph/customize.py
@@ -1,0 +1,138 @@
+from utils import is_true
+import os
+import glob
+
+
+# The lstopo capture written by get-mlperf-single-node-system-info,_lstopo
+# shares its stem with that node's sysinfo JSON:
+#   mlperf-system-info-single-node-2.json
+#   mlperf-system-info-single-node-2.lstopo.xml
+# Pairing on the stem is what lets this script work for a directory produced by
+# any caller, single node or multi node, without being told a node list.
+_TOPOLOGY_SUFFIX = '.lstopo.xml'
+
+# infragraph >= 3.0 uses PEP 604 annotations (`str | None`) at class-definition
+# time, so on an older interpreter it does not fail to install -- it fails to
+# import, with a TypeError that says nothing about Python versions.
+_MIN_PYTHON = (3, 10)
+
+
+def _python_version(env):
+    """(major, minor) of the interpreter MLC selected, or None if unreadable."""
+    raw = env.get('MLC_PYTHON_VERSION', '')
+    parts = str(raw).split('.')
+    if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+        return (int(parts[0]), int(parts[1]))
+    return None
+
+
+def _discover_nodes(input_dir):
+    """Every (stem, xml, sysinfo_or_None) triple found in input_dir.
+
+    Sorted so that node-2 lands after node-10 in numeric rather than
+    lexicographic order -- the ordering shows up in the merged graph's
+    instance list, and a jumbled one is confusing to read against the
+    submission's node numbering.
+    """
+    nodes = []
+    for xml in glob.glob(os.path.join(input_dir, '*' + _TOPOLOGY_SUFFIX)):
+        stem = os.path.basename(xml)[:-len(_TOPOLOGY_SUFFIX)]
+        sysinfo = os.path.join(input_dir, stem + '.json')
+        nodes.append((stem, xml, sysinfo if os.path.isfile(sysinfo) else None))
+    return sorted(nodes, key=lambda n: _sort_key(n[0]))
+
+
+def _sort_key(stem):
+    """Natural sort: trailing digits compare numerically, rest lexically."""
+    head = stem.rstrip('0123456789')
+    tail = stem[len(head):]
+    return (head, int(tail) if tail else -1)
+
+
+def preprocess(i):
+
+    env = i['env']
+    logger = i['automation'].logger
+
+    # version_min on the python dep is ignored when MLC_PYTHON_BIN_WITH_PATH
+    # is already set by an enclosing script -- get-python3 keeps the inherited
+    # interpreter rather than searching for one. Check here so the failure
+    # names the real problem instead of surfacing as an import TypeError.
+    version = _python_version(env)
+    if version and version < _MIN_PYTHON:
+        want = '.'.join(str(v) for v in _MIN_PYTHON)
+        return {'return': 1,
+                'error': f'infragraph needs Python >= {want}, but MLC selected '
+                         f'{env.get("MLC_PYTHON_BIN_WITH_PATH", "?")} '
+                         f'(version {env.get("MLC_PYTHON_VERSION", "?")}). '
+                         'Point MLC at a newer interpreter, e.g. '
+                         '`mlc rm cache --tags=get,python3` then re-run, or '
+                         'pass --adr.python.version_min=' + want + ' to the '
+                         'top-level script.'}
+
+    input_dir = env.get('MLC_INFRAGRAPH_INPUT_DIR_PATH', '') or os.getcwd()
+    input_dir = os.path.abspath(input_dir)
+    if not os.path.isdir(input_dir):
+        return {'return': 1,
+                'error': f'Input directory does not exist: {input_dir}'}
+    env['MLC_INFRAGRAPH_INPUT_DIR_PATH'] = input_dir
+
+    out_dir = env.get('MLC_INFRAGRAPH_OUT_DIR_PATH', '') or input_dir
+    out_dir = os.path.abspath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    env['MLC_INFRAGRAPH_OUT_DIR_PATH'] = out_dir
+
+    file_name = env.get('MLC_INFRAGRAPH_FILE_NAME', '') or 'infragraph.json'
+    env['MLC_INFRAGRAPH_FILE_PATH'] = os.path.join(out_dir, file_name)
+    env['MLC_INFRAGRAPH_YAML_FILE_PATH'] = os.path.join(
+        out_dir, os.path.splitext(file_name)[0] + '.yaml')
+    env['MLC_INFRAGRAPH_VISUALS_DIR_PATH'] = os.path.join(out_dir, 'visuals')
+
+    nodes = _discover_nodes(input_dir)
+    if not nodes:
+        return {'return': 1,
+                'error': f'No *{_TOPOLOGY_SUFFIX} topology files found in '
+                         f'{input_dir}. Run the system-info collection with '
+                         'the _infragraph variation (or get,mlperf,single-'
+                         'node,system-info with _lstopo) so each node writes '
+                         'its hwloc topology next to its sysinfo JSON.'}
+
+    for stem, _xml, sysinfo in nodes:
+        if sysinfo is None:
+            logger.warning(
+                f'{stem}: topology found but no matching {stem}.json sysinfo; '
+                'this node will appear in the graph without processor or '
+                'accelerator attributes.')
+    logger.info(
+        f'Building infrastructure graph from {len(nodes)} node topology '
+        f'file(s) in {input_dir}')
+
+    env['MLC_INFRAGRAPH_NODE_COUNT'] = str(len(nodes))
+
+    # An empty MLC_MLPERF_SYSTEM_NAME templates through to an empty string
+    # rather than being absent, so test for content, not for the key.
+    if not env.get('MLC_INFRAGRAPH_NAME', '').strip():
+        env['MLC_INFRAGRAPH_NAME'] = (
+            'single-node-system' if len(nodes) == 1 else 'multi-node-system')
+
+    return {'return': 0}
+
+
+def postprocess(i):
+
+    env = i['env']
+    logger = i['automation'].logger
+
+    out_path = env.get('MLC_INFRAGRAPH_FILE_PATH', '')
+    if not out_path or not os.path.isfile(out_path):
+        return {'return': 1,
+                'error': f'Expected the infrastructure graph at {out_path}, '
+                         'but it was not produced.'}
+
+    # Visuals are optional, so only advertise the directory when it is there.
+    if not os.path.isdir(env.get('MLC_INFRAGRAPH_VISUALS_DIR_PATH', '')):
+        del env['MLC_INFRAGRAPH_VISUALS_DIR_PATH']
+
+    logger.info(f'Infrastructure graph written to {out_path}')
+
+    return {'return': 0}

--- a/script/generate-infograph/info.md
+++ b/script/generate-infograph/info.md
@@ -1,0 +1,103 @@
+# generate-infograph
+
+Builds an [infragraph](https://pypi.org/project/infragraph/) infrastructure
+graph from a directory of per-node system-info captures, and renders an
+interactive HTML view of it.
+
+It is normally not run by hand. `get-mlperf-multi-node-system-info,_infragraph`
+runs it as a `post_dep` once every node has reported in, which is the path most
+people want. Running it directly is useful when you already have the captures
+on disk and want to rebuild the graph — after editing a topology by hand, say,
+or to re-render the visuals without re-probing the cluster.
+
+## What it reads
+
+The input directory is expected to hold, for each node, an hwloc topology and
+the sysinfo JSON that shares its stem:
+
+```
+mlperf-system-info-single-node-0.lstopo.xml
+mlperf-system-info-single-node-0.json
+mlperf-system-info-single-node-1.lstopo.xml
+mlperf-system-info-single-node-1.json
+```
+
+That pairing is the whole contract. The `.lstopo.xml` files come from
+`get-mlperf-single-node-system-info,_lstopo`, which parks the topology beside
+the JSON with a matching stem for exactly this reason. Nodes are discovered
+from what is on disk rather than from a node list, so one node in gives you a
+single-node graph and N nodes give you a multi-node one, through the same code
+path.
+
+A topology with no matching JSON still gets into the graph — it just carries no
+processor or accelerator attributes, and a warning says so.
+
+## What it writes
+
+| File | Contents |
+|------|----------|
+| `infragraph.json` | The annotated graph: the merged `Infrastructure` plus the per-node sysinfo attached to each node's `cpu` and `xpu` components. This is the artifact to keep. |
+| `infragraph.yaml` | The merged `Infrastructure` definition on its own, without annotations. |
+| `dev-<stem>.yaml` | One per node: the raw `infragraph translate lstopo` output, kept as an intermediate so a bad merge can be traced back to the node that caused it. |
+| `visuals/` | A self-contained HTML/JS bundle; open `visuals/index.html` in a browser. Suppressed by `_no_visualize`. |
+
+## Usage
+
+```bash
+mlcr generate,infograph --input_dir=/tmp/sysinfo --graph_name=my-cluster
+```
+
+Rebuild the graph but skip the HTML bundle:
+
+```bash
+mlcr generate,infograph,_no_visualize --input_dir=/tmp/sysinfo
+```
+
+Write the graph somewhere other than next to the inputs:
+
+```bash
+mlcr generate,infograph \
+  --input_dir=/tmp/sysinfo \
+  --out_dir_path=/tmp/graph \
+  --out_file_name=cluster.json
+```
+
+## Parameters
+
+| Flag | Env var | Meaning |
+|------|---------|---------|
+| `--input_dir` | `MLC_INFRAGRAPH_INPUT_DIR_PATH` | Directory holding the per-node captures. Defaults to the current directory. |
+| `--out_dir_path` | `MLC_INFRAGRAPH_OUT_DIR_PATH` | Where to write the graph and visuals. Defaults to the input directory. |
+| `--out_file_name` | `MLC_INFRAGRAPH_FILE_NAME` | Name of the annotated graph JSON. Defaults to `infragraph.json`; the YAML takes the same stem. |
+| `--graph_name` | `MLC_INFRAGRAPH_NAME` | Name recorded in the graph. Defaults to `single-node-system` or `multi-node-system` depending on how many nodes were found. |
+
+## Variations
+
+| Tag | Effect |
+|-----|--------|
+| `_no_visualize` | Skip the HTML visualizer bundle. The JSON and YAML are still produced. |
+
+## How the merge works
+
+Each node's topology becomes one infragraph *device*. Devices that are
+structurally identical are stored once and instantiated per node, so a
+homogeneous cluster yields one device definition rather than N copies of it.
+Instances are named after each node's real hostname, read from the `HostName`
+field lstopo records in its own XML — that is what puts node identity into
+generated graph node names (`mlc2.0.cpu.0`) and lets each node be annotated
+with its own sysinfo. Two nodes reporting the same hostname get suffixed
+(`mlc2`, `mlc2-2`) rather than silently collapsing into one.
+
+No infrastructure-level edges are emitted. lstopo sees one host at a time, so
+there is no observable inter-node fabric to infer; the merged graph is a set of
+per-node subgraphs, not a fabric topology.
+
+## Requirements
+
+- **Python 3.10 or newer.** infragraph 3.x uses PEP 604 annotations at import
+  time, so on 3.9 it fails to import rather than failing to install. The script
+  checks the interpreter MLC selected and says so up front. If MLC picks an
+  older Python, pass `--adr.python.version_min=3.10` or clear the stale
+  `get,python3` cache entry.
+- `lstopo` is **not** needed here — the topologies were captured on the nodes
+  themselves. Only the machine running the collection needs infragraph.

--- a/script/generate-infograph/meta.yaml
+++ b/script/generate-infograph/meta.yaml
@@ -1,0 +1,61 @@
+alias: generate-infograph
+uid: 6e48fe6ca033f490
+automation_alias: script
+automation_uid: 5b4e0237da074764
+
+# Metadata
+category: Platform information
+tags:
+- generate
+- infograph
+- infragraph
+
+# Cache
+cache: false
+
+# Environment
+new_env_keys:
+- MLC_INFRAGRAPH_FILE_PATH
+- MLC_INFRAGRAPH_YAML_FILE_PATH
+- MLC_INFRAGRAPH_VISUALS_DIR_PATH
+- MLC_INFRAGRAPH_NODE_COUNT
+
+# Input mapping
+input_mapping:
+  input_dir: MLC_INFRAGRAPH_INPUT_DIR_PATH
+  graph_name: MLC_INFRAGRAPH_NAME
+  out_dir_path: MLC_INFRAGRAPH_OUT_DIR_PATH
+  out_file_name: MLC_INFRAGRAPH_FILE_NAME
+
+default_env:
+  MLC_INFRAGRAPH_FILE_NAME: infragraph.json
+
+clean_files:
+- tmp-run-env.out
+
+# Dependencies
+deps:
+- tags: detect,os
+# infragraph >= 3.0 uses PEP 604 (`str | None`) annotations at import time,
+# so it fails on 3.9 with a TypeError rather than a clean install error.
+- tags: get,python
+  names:
+  - python
+  - python3
+  version_min: '3.10'
+- tags: get,generic-python-lib,_package.infragraph
+  names:
+  - infragraph
+
+# Variations
+variations:
+  # Skip the HTML visualizer bundle; the graph JSON/YAML is still produced.
+  no_visualize:
+    env:
+      MLC_INFRAGRAPH_SKIP_VISUALIZE: 'True'
+
+# Output / debugging
+print_env_at_the_end:
+  MLC_INFRAGRAPH_FILE_PATH: Path to the annotated infrastructure graph JSON.
+  MLC_INFRAGRAPH_YAML_FILE_PATH: Path to the merged infrastructure graph YAML.
+  MLC_INFRAGRAPH_VISUALS_DIR_PATH: Directory holding the generated infragraph visualizer files.

--- a/script/generate-infograph/run.sh
+++ b/script/generate-infograph/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+VISUALS_DIR="${MLC_INFRAGRAPH_VISUALS_DIR_PATH}"
+if [[ "${MLC_INFRAGRAPH_SKIP_VISUALIZE}" == "True" ]]; then
+    VISUALS_DIR=""
+fi
+
+# infragraph is driven through its Python API rather than its console script:
+# get,generic-python-lib installs it into the MLC-selected interpreter, whose
+# bin directory is not necessarily on PATH.
+"${MLC_PYTHON_BIN_WITH_PATH}" "${MLC_TMP_CURRENT_SCRIPT_PATH}/build_infragraph.py" \
+    --input-dir "${MLC_INFRAGRAPH_INPUT_DIR_PATH}" \
+    --output "${MLC_INFRAGRAPH_FILE_PATH}" \
+    --output-yaml "${MLC_INFRAGRAPH_YAML_FILE_PATH}" \
+    --name "${MLC_INFRAGRAPH_NAME}" \
+    --visuals-dir "${VISUALS_DIR}"

--- a/script/get-lstopo/meta.yaml
+++ b/script/get-lstopo/meta.yaml
@@ -15,6 +15,14 @@ category: lstopo topology automation
 new_env_keys:
 - MLC_LSTOPO_XML_FILE_PATH
 
+# Input mapping
+input_mapping:
+  out_dir_path: MLC_LSTOPO_OUT_DIR_PATH
+  out_file_name: MLC_LSTOPO_OUT_FILE_NAME
+
+default_env:
+  MLC_LSTOPO_OUT_FILE_NAME: topo.xml
+
 clean_files:
 - tmp-run-env.out
 

--- a/script/get-lstopo/run.sh
+++ b/script/get-lstopo/run.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 
 set -e
-rm -f topo.xml
-lstopo topo.xml
-echo "MLC_LSTOPO_XML_FILE_PATH=$(pwd)/topo.xml" > tmp-run-env.out
-echo "topo.xml written to $(pwd)/topo.xml"
+
+# Where the topology lands. Defaults keep the historical behaviour (topo.xml
+# in the caller's cwd) so existing users of get,lstopo are unaffected; callers
+# that need a predictable path -- e.g. get-mlperf-single-node-system-info,
+# which parks the XML next to the sysinfo JSON so both can be copied back from
+# a remote node together -- set these two.
+OUT_DIR="${MLC_LSTOPO_OUT_DIR_PATH:-$(pwd)}"
+OUT_FILE="${MLC_LSTOPO_OUT_FILE_NAME:-topo.xml}"
+
+mkdir -p "${OUT_DIR}"
+OUT_PATH="${OUT_DIR}/${OUT_FILE}"
+
+rm -f "${OUT_PATH}"
+lstopo "${OUT_PATH}"
+echo "MLC_LSTOPO_XML_FILE_PATH=${OUT_PATH}" > tmp-run-env.out
+echo "lstopo topology written to ${OUT_PATH}"

--- a/script/get-mlperf-multi-node-system-info/customize.py
+++ b/script/get-mlperf-multi-node-system-info/customize.py
@@ -115,6 +115,25 @@ def _parse_node(node_str):
     return user, host, port
 
 
+_REMOTE_SINGLE_NODE_DIR = "/tmp/mlperf-system-info-single-node"
+
+
+def _files_to_copy_back(node_id, collect_lstopo):
+    """Remote artifacts to pull back for one node.
+
+    The lstopo XML shares the sysinfo JSON's stem by construction -- see
+    get-mlperf-single-node-system-info's preprocess() -- so its remote name is
+    predictable from the node id alone. A node running an older copy of the
+    automations repo will not produce it; rsync logs that miss and the run
+    continues, and generate-infograph simply omits that node from the graph.
+    """
+    stem = f"{_REMOTE_SINGLE_NODE_DIR}/mlperf-system-info-single-node-{node_id}"
+    files = [f"{stem}.json"]
+    if collect_lstopo:
+        files.append(f"{stem}.lstopo.xml")
+    return files
+
+
 def preprocess(i):
 
     env = i['env']
@@ -144,6 +163,14 @@ def preprocess(i):
         backend = env.get('MLC_ACCELERATOR_BACKEND', '')
         if backend in ('cuda', 'rocm', 'xpu'):
             rr_tags += f",_{backend}"
+
+        # Under _infragraph each node also captures its hwloc topology. The
+        # tag is passed explicitly rather than relying on env inheritance,
+        # because the remote node resolves its own variations from the tag
+        # string it is given.
+        collect_lstopo = is_true(env.get('MLC_COLLECT_LSTOPO_TOPOLOGY', False))
+        if collect_lstopo:
+            rr_tags += ",_lstopo"
         ssh_ids = [
             s.strip() for s in env['MLC_MULTINODE_SYSTEM_SSH_IDS'].split(',') if s.strip()]
 
@@ -163,11 +190,11 @@ def preprocess(i):
                     'run_cmd': rr_tags,
                     'mlc_run_cmd': f"mlcr {rr_tags}",
                     'node_id': actual_node_id,
-                    'out_dir_path': "/tmp/mlperf-system-info-single-node",
+                    'out_dir_path': _REMOTE_SINGLE_NODE_DIR,
                     'remote_host': host,
                     'remote_user': user,
                     'remote_port': port,
-                    'files_to_copy_back': [f"/tmp/mlperf-system-info-single-node/mlperf-system-info-single-node-{actual_node_id}.json"],
+                    'files_to_copy_back': _files_to_copy_back(actual_node_id, collect_lstopo),
                     'path_to_copy_back_files': env['MLC_MULTI_NODE_SYSTEM_INFO_DIR_PATH'],
                     'run_state': run_state,
                     'skip_ssh_key_file': env.get('MLC_SKIP_SSH_KEY_FILE', ''),

--- a/script/get-mlperf-multi-node-system-info/info.md
+++ b/script/get-mlperf-multi-node-system-info/info.md
@@ -348,6 +348,48 @@ Specify one of `_cuda`, `_rocm`, or `_xpu` to match your hardware. If none is gi
 | `_power` | Adds the power submission extra fields (`power_supply_quantity_and_rating_watts`, `power_supply_details`, `boot_firmware_version`, etc.) to the output as blank strings for manual entry. Stack with `_inference`. |
 | `_redfish` | Runs [`get-redfish-power-info`](../get-redfish-power-info/README.md) as a `prehook_dep` to capture live PSU data from a Redfish BMC/mockup endpoint. On its own, just produces a raw capture YAML in the output dir for reference. |
 | `_inference_optional_nameplate` | Produces the nameplate power YAML the MLPerf Inference submission_checker optionally accepts (see [Nameplate power YAML](#nameplate-power-yaml-_redfish_inference_optional_nameplate)). Stacked with `_redfish`, it's populated with real PSU data from the BMC; used **alone**, it writes the generic fill-in-the-blanks skeleton template instead — no BMC is contacted. |
+| `_infragraph` | Captures an hwloc topology on every node alongside its sysinfo, then builds an infrastructure graph from the whole set (see [Infrastructure graph](#infrastructure-graph-_infragraph)). |
+| `_no_visualize` | Only meaningful with `_infragraph`: skip the HTML visualizer bundle and produce just the graph JSON and YAML. |
+
+### Infrastructure graph (`_infragraph`)
+
+`_infragraph` adds a topology layer on top of the sysinfo collection. Each node
+captures its own hwloc topology while it is already being probed — no second SSH
+pass — and once every node has reported in, [`generate-infograph`](../generate-infograph/README.md)
+runs as a `post_dep` and merges the lot into one
+[infragraph](https://pypi.org/project/infragraph/) infrastructure graph,
+annotated with each node's processor and accelerator details.
+
+```bash
+mlcr get-mlperf-multi-node-system-info,_cuda,_infragraph \
+  --ssh_ids=user@node1:22,user@node2:22 \
+  --out_dir_path=/tmp/sysinfo \
+  --system_name=my-cluster
+```
+
+Alongside the usual system-info output, `/tmp/sysinfo` then holds:
+
+| File | Contents |
+|------|----------|
+| `infragraph.json` | The annotated graph — merged topology plus each node's sysinfo attached to its `cpu` and `xpu` components. |
+| `infragraph.yaml` | The merged `Infrastructure` definition without annotations. |
+| `mlperf-system-info-single-node-<id>.lstopo.xml` | Per-node hwloc topology, one per node. |
+| `dev-mlperf-system-info-single-node-<id>.yaml` | Per-node translated device definition (intermediate). |
+| `visuals/index.html` | Interactive browser view of the graph. |
+
+The graph is named after `--system_name` when one is given. It works the same
+way with one node as with many: run without `--ssh_ids` and you get a
+single-node graph of the local machine.
+
+Two things this needs that the plain collection does not:
+
+- **`hwloc` on every node.** It is installed by the `get,lstopo` dependency
+  where a package manager is available. A node that cannot produce a topology
+  is left out of the graph with a warning rather than failing the run.
+- **Python 3.10+ and `infragraph` on the machine running the collection.** The
+  remote nodes only need `lstopo`; the graph itself is built locally.
+
+Add `_no_visualize` to skip the HTML bundle.
 
 ### Example: inference submission with power fields
 

--- a/script/get-mlperf-multi-node-system-info/meta.yaml
+++ b/script/get-mlperf-multi-node-system-info/meta.yaml
@@ -16,6 +16,9 @@ new_env_keys:
 - MLC_REMOTE_RUN_SSH_ID_COUNT
 - MLC_MULTI_NODE_SYSTEM_INFO_FILE_PATH
 - MLC_NAMEPLATE_POWER_YAML_FILE_PATH
+# Produced by the generate-infograph post dep under _infragraph; re-exported
+# here so callers of this script see the graph paths too.
+- MLC_INFRAGRAPH_*
 
 # Input mapping
 input_mapping:
@@ -118,6 +121,22 @@ prehook_deps:
     # ordinary env inheritance, not self-referential templates.
     MLC_REDFISH_OUTPUT_FILE: <<<MLC_MULTI_NODE_SYSTEM_INFO_DIR_PATH>>>/redfish_capture.yaml
 
+# Runs after postprocess(), so every node's sysinfo JSON and its lstopo XML are
+# already sitting in MLC_MULTI_NODE_SYSTEM_INFO_DIR_PATH by the time the graph
+# is built. generate-infograph discovers the per-node pairs in that directory
+# itself rather than being handed a node list, so the two scripts never have to
+# agree on node numbering.
+post_deps:
+- tags: generate,infograph
+  names:
+  - generate-infograph
+  enable_if_env:
+    MLC_MLPERF_INFRAGRAPH_ENABLED:
+    - 'True'
+  env:
+    MLC_INFRAGRAPH_INPUT_DIR_PATH: <<<MLC_MULTI_NODE_SYSTEM_INFO_DIR_PATH>>>
+    MLC_INFRAGRAPH_NAME: <<<MLC_MLPERF_SYSTEM_NAME>>>
+
 # Variations
 variations:
   cuda:
@@ -164,8 +183,23 @@ variations:
   inference_optional_nameplate:
     env:
       MLC_MLPERF_INFERENCE_OPTIONAL_NAMEPLATE_ENABLED: 'True'
+  # Capture an hwloc topology per node alongside the sysinfo, then build the
+  # infrastructure graph from the whole set once every node has reported in.
+  # MLC_COLLECT_LSTOPO_TOPOLOGY is inherited by the local single-node dep; the
+  # remote nodes get it as an explicit _lstopo tag in preprocess().
+  infragraph:
+    env:
+      MLC_MLPERF_INFRAGRAPH_ENABLED: 'True'
+      MLC_COLLECT_LSTOPO_TOPOLOGY: 'True'
+  # Skip the HTML visualizer bundle; the graph JSON/YAML is still produced.
+  no_visualize:
+    env:
+      MLC_INFRAGRAPH_SKIP_VISUALIZE: 'True'
 
 # Output / debugging
 print_env_at_the_end:
+  MLC_INFRAGRAPH_FILE_PATH: Path to the annotated infrastructure graph JSON (with _infragraph).
+  MLC_INFRAGRAPH_YAML_FILE_PATH: Path to the merged infrastructure graph YAML (with _infragraph).
+  MLC_INFRAGRAPH_VISUALS_DIR_PATH: Directory holding the generated infragraph visualizer files.
   MLC_MULTI_NODE_SYSTEM_INFO_FILE_PATH: Path to the generated multi-node system info file.
   MLC_NAMEPLATE_POWER_YAML_FILE_PATH: Path to the generated nameplate power YAML file (populated from Redfish with _redfish,_inference_optional_nameplate; a generic skeleton template with _inference_optional_nameplate alone).

--- a/script/get-mlperf-single-node-system-info/customize.py
+++ b/script/get-mlperf-single-node-system-info/customize.py
@@ -1,4 +1,5 @@
 from mlc import utils
+from utils import is_true
 import os
 import json
 import subprocess
@@ -18,6 +19,21 @@ def preprocess(i):
 
     if not os.path.exists(env['MLC_SINGLE_NODE_SYSTEM_INFO_DIR_PATH']):
         os.makedirs(env['MLC_SINGLE_NODE_SYSTEM_INFO_DIR_PATH'], exist_ok=True)
+
+    # With _lstopo, get,lstopo runs as a prehook dep and parks this node's
+    # topology beside the sysinfo JSON, sharing its stem:
+    #   mlperf-system-info-single-node-3.json
+    #   mlperf-system-info-single-node-3.lstopo.xml
+    # The shared stem is the contract generate-infograph pairs on, and it is
+    # what lets get-mlperf-multi-node-system-info predict the remote filename
+    # it has to copy back without a second round trip. Both keys are set only
+    # when the capture is enabled, so a plain run exports nothing about a
+    # topology it never took.
+    if is_true(env.get('MLC_COLLECT_LSTOPO_TOPOLOGY', False)):
+        info_path = env['MLC_SINGLE_NODE_SYSTEM_INFO_FILE_PATH']
+        xml_path = os.path.splitext(info_path)[0] + '.lstopo.xml'
+        env['MLC_SINGLE_NODE_LSTOPO_XML_FILE_NAME'] = os.path.basename(xml_path)
+        env['MLC_SINGLE_NODE_LSTOPO_XML_FILE_PATH'] = xml_path
 
     CMD = f"""{env['MLC_PYTHON_BIN_WITH_PATH']} {env['MLC_TMP_CURRENT_SCRIPT_PATH']}/parse.py --output {env['MLC_SINGLE_NODE_SYSTEM_INFO_FILE_PATH']}"""
 
@@ -40,6 +56,17 @@ def postprocess(i):
     # produced it (traceability, since mlc-scripts has no tagged release).
     output_path = env.get('MLC_SINGLE_NODE_SYSTEM_INFO_FILE_PATH', '')
     repo_path = env.get('MLC_TMP_CURRENT_SCRIPT_REPO_PATH', '')
+
+    # Only advertise the topology path if the capture actually happened --
+    # a dangling path reads as "there is a topology here" to callers.
+    xml_path = env.get('MLC_SINGLE_NODE_LSTOPO_XML_FILE_PATH', '')
+    if xml_path and not os.path.isfile(xml_path):
+        automation.logger.warning(
+            f"_lstopo was requested but no topology was written to "
+            f"{xml_path}; this node will have no entry in the "
+            f"infrastructure graph.")
+        del env['MLC_SINGLE_NODE_LSTOPO_XML_FILE_PATH']
+
     if output_path and os.path.exists(output_path):
         try:
             from mlc.utils import get_repo_version

--- a/script/get-mlperf-single-node-system-info/meta.yaml
+++ b/script/get-mlperf-single-node-system-info/meta.yaml
@@ -19,6 +19,8 @@ new_env_keys:
 - MLC_SINGLE_NODE_SYSTEM_INFO_FILE_PATH
 - MLC_SINGLE_NODE_SYSTEM_INFO_DIR_PATH
 - MLC_SINGLE_NODE_SYSTEM_INFO_FILE_NAME
+- MLC_SINGLE_NODE_LSTOPO_XML_FILE_PATH
+- MLC_SINGLE_NODE_LSTOPO_XML_FILE_NAME
 
 # Input mapping
 input_mapping:
@@ -61,8 +63,29 @@ deps:
   - platform-details
 - tags: detect,host,system,details
 
+# The lstopo capture has to sit next to the sysinfo JSON, and that path is only
+# resolved in preprocess(), so this is a prehook dep rather than a plain dep.
+prehook_deps:
+- tags: get,lstopo
+  names:
+  - lstopo
+  enable_if_env:
+    MLC_COLLECT_LSTOPO_TOPOLOGY:
+    - 'True'
+  env:
+    MLC_LSTOPO_OUT_DIR_PATH: <<<MLC_SINGLE_NODE_SYSTEM_INFO_DIR_PATH>>>
+    MLC_LSTOPO_OUT_FILE_NAME: <<<MLC_SINGLE_NODE_LSTOPO_XML_FILE_NAME>>>
+
 # Variations
 variations:
+  # Capture this node's hwloc topology alongside the sysinfo JSON. Used by
+  # get-mlperf-multi-node-system-info,_infragraph, which needs one lstopo XML
+  # per node to build the infrastructure graph -- collecting it here means the
+  # existing sysinfo fan-out carries the topology back too, with no second SSH
+  # pass.
+  lstopo:
+    env:
+      MLC_COLLECT_LSTOPO_TOPOLOGY: 'True'
   cuda:
     group: accelerator-backend
     env:


### PR DESCRIPTION
Adds an infragraph infrastructure-graph layer on top of the multi-node system-info collection, without a second SSH pass for topology.

The topology rides along with the sysinfo that is already being collected per node:

- get-lstopo gains --out_dir_path / --out_file_name so callers can put the XML somewhere predictable. Defaults are unchanged.

- get-mlperf-single-node-system-info gains a _lstopo variation. It runs get,lstopo as a prehook dep -- the output directory is only resolved in preprocess(), so a plain dep would run too early -- and writes <sysinfo-stem>.lstopo.xml beside the JSON. That shared stem is the whole pairing contract, and it is what lets the multi-node script predict the remote filename it has to copy back.

- get-mlperf-multi-node-system-info gains _infragraph, which appends _lstopo to the remote tags, adds the XML to files_to_copy_back, and runs the new generate-infograph script as a post_dep. post_deps run after postprocess(), so every node has reported in by then.

- generate-infograph (new) merges the per-node topologies into one Infrastructure, annotates each node's cpu / xpu components from that node's sysinfo, and renders the HTML visualizer. It discovers the node pairs by globbing the input directory rather than being handed a node list, so it never has to agree with the caller on node numbering, and one node in yields a single-node graph while N yield a multi-node one through the same path. Structurally identical devices are stored once and instantiated per node; instances are named after each node's real hostname, with a suffix when two nodes report the same one.

_infragraph is opt-in: turning it on unconditionally would make hwloc and infragraph hard dependencies of a script that many callers already run. Without the tag, nothing about this change is reachable.

infragraph 3.x needs Python >= 3.10 (it uses PEP 604 annotations at import time, so on 3.9 it fails to import rather than to install). version_min on the python dep is ignored whenever an enclosing script already resolved MLC_PYTHON_BIN_WITH_PATH, so generate-infograph checks the selected interpreter in preprocess() and names the problem instead of letting it surface as a bare TypeError.

Tested with the local workstation as node 0 and a remote 8x H100 node as node 1: two-node, single-node, _exclude_current_node, homogeneous deduplication, standalone generate-infograph with _no_visualize, and a regression check confirming the default path produces no topology capture and no graph.

### 🧾 PR Checklist

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed

### 📝 Comments & Communication
- [ ] Proper inline comments are added to explain important or non-obvious changes
- [ ] PR title and description clearly state what the PR does and why
- [ ] Related issues (if any) are properly referenced (`Fixes #`, `Related to #`, etc.)

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed
- [ ] Paths, shell commands, and environment handling are safe and portable

