### PR TITLE
Add service-account authentication for gated r2-downloader downloads

### DIFF
--- a/script/download-and-extract/README.md
+++ b/script/download-and-extract/README.md
@@ -40,6 +40,9 @@ mlcr download-and-extract file
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--download_path` |  |  | `` |
 | `--extra_folder` |  |  | `` |
 | `--extract_path` |  |  | `` |
@@ -89,4 +92,5 @@ mlcr download-and-extract file
 
 - `extract`
 - `extract-to-download-dir`
+- `service-account`
 - `url.#` _(# can be substituted dynamically)_

--- a/script/download-and-extract/meta.yaml
+++ b/script/download-and-extract/meta.yaml
@@ -33,10 +33,19 @@ input_mapping:
   extract_path: MLC_EXTRACT_PATH
   from: MLC_DOWNLOAD_LOCAL_FILE_PATH
   local_path: MLC_DOWNLOAD_LOCAL_FILE_PATH
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
   store: MLC_DOWNLOAD_PATH
   to: MLC_EXTRACT_PATH
   url: MLC_DAE_URL
-input_description: {}
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Dependencies
 deps: []
@@ -144,6 +153,9 @@ variations:
   extract-to-download-dir:
     env:
       MLC_DAE_EXTRACT_TO_DOWNLOADED: 'yes'
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
   url.#:
     env:
       MLC_DAE_URL: '#'

--- a/script/download-file/README.md
+++ b/script/download-file/README.md
@@ -40,6 +40,9 @@ mlcr download file
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--download_path` |  |  | `` |
 | `--from` |  |  | `` |
 | `--local_path` | Alias for from |  | `` |
@@ -80,4 +83,5 @@ mlcr download file
 
 ### Ungrouped
 
+- `service-account`
 - `url.#` _(# can be substituted dynamically)_

--- a/script/download-file/customize.py
+++ b/script/download-file/customize.py
@@ -147,6 +147,13 @@ def preprocess(i):
 
         extra_download_options = env.get('MLC_DOWNLOAD_EXTRA_OPTIONS', '')
 
+        use_service_account = is_true(
+            env.get('MLC_AUTH_USING_SERVICE_ACCOUNT'))
+        if use_service_account and tool != "r2-downloader":
+            logger.warning(
+                "Ignoring --use_service_account: service-account authentication is "
+                f"only supported by the r2-downloader tool, not '{tool}'")
+
         verify_ssl = is_true(env.get('MLC_VERIFY_SSL', "True"))
         if not verify_ssl or os_info['platform'] == 'windows':
             verify_ssl = False
@@ -307,7 +314,22 @@ def preprocess(i):
             logger.info(f"{env['MLC_DOWNLOAD_CMD']}")
 
         elif tool == "r2-downloader":
-            if is_true(env.get('MLC_AUTH_USING_SERVICE_ACCOUNT')):
+            # Non-interactive authentication for Cloudflare Access gated
+            # buckets. The downloader reads the credentials from its own
+            # environment, so check them here: without -s it would fall back to
+            # a browser-based login that can never complete on a headless
+            # machine, and with -s but no credentials it would only fail deep
+            # inside the downloader.
+            if use_service_account:
+                missing = [
+                    key for key in (
+                        'CF_ACCESS_CLIENT_ID',
+                        'CF_ACCESS_CLIENT_SECRET') if not env.get(key) and not os.environ.get(key)]
+                if missing:
+                    return {'return': 1,
+                            'error': "service-account authentication was requested but the "
+                            "following are not set: " + ", ".join(missing) +
+                            ". Export them, or pass --r2_client_id=... --r2_client_secret=..."}
                 extra_download_options += " -s "
             env['MLC_DOWNLOAD_CMD'] = f"bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) "
             if env["MLC_HOST_OS_TYPE"] == "windows":

--- a/script/download-file/meta.yaml
+++ b/script/download-file/meta.yaml
@@ -33,9 +33,18 @@ input_mapping:
   local_path: MLC_DOWNLOAD_LOCAL_FILE_PATH
   md5sum: MLC_DOWNLOAD_CHECKSUM
   output_file: MLC_DOWNLOAD_FILENAME
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
   store: MLC_DOWNLOAD_PATH
   url: MLC_DOWNLOAD_URL
-input_description: {}
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Dependencies
 deps:
@@ -91,6 +100,9 @@ variations:
     group: download-tool
   cmutil:
     alias: mlcutil
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
   url.#:
     env:
       MLC_DOWNLOAD_URL: '#'

--- a/script/get-dataset-waymo-calibration/README.md
+++ b/script/get-dataset-waymo-calibration/README.md
@@ -40,6 +40,9 @@ mlcr get,waymo,dataset,calibration
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--waymo_calibration_path` |  |  | `` |
 ### Generic Script Inputs
 
@@ -79,3 +82,7 @@ mlcr get,waymo,dataset,calibration
 ### Run-mode
 
 - `dry-run`
+
+### Ungrouped
+
+- `service-account`

--- a/script/get-dataset-waymo-calibration/meta.yaml
+++ b/script/get-dataset-waymo-calibration/meta.yaml
@@ -19,7 +19,17 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
   waymo_calibration_path: MLC_DATASET_WAYMO_CALIBRATION_PATH
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Variations
 variations:
@@ -89,11 +99,14 @@ variations:
   rclone,mlc:
     env:
       MLC_DOWNLOAD_URL: mlc_waymo:waymo_preprocessed_dataset/kitti_format/testing
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
 
 # Tests
 tests:
   needs_pat: true
   run_inputs:
   - variations_list:
-    - r2-downloader,mlc,dry-run
+    - r2-downloader,mlc,dry-run,service-account
     - rclone,mlc,dry-run

--- a/script/get-dataset-waymo/README.md
+++ b/script/get-dataset-waymo/README.md
@@ -40,6 +40,9 @@ mlcr get,dataset,waymo
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--waymo_path` |  |  | `` |
 ### Generic Script Inputs
 
@@ -79,3 +82,7 @@ mlcr get,dataset,waymo
 ### Run-mode
 
 - `dry-run`
+
+### Ungrouped
+
+- `service-account`

--- a/script/get-dataset-waymo/meta.yaml
+++ b/script/get-dataset-waymo/meta.yaml
@@ -18,7 +18,17 @@ new_env_keys:
 
 # Input mapping
 input_mapping:
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
   waymo_path: MLC_DATASET_WAYMO_PATH
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Variations
 variations:
@@ -87,11 +97,14 @@ variations:
   rclone,mlc:
     env:
       MLC_DOWNLOAD_URL: mlc_waymo:waymo_preprocessed_dataset/kitti_format
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
 
 # Tests
 tests:
   needs_pat: true
   run_inputs:
   - variations_list:
-    - r2-downloader,mlc,dry-run
+    - r2-downloader,mlc,dry-run,service-account
     - rclone,mlc,dry-run

--- a/script/get-ml-model-abtf-ssd-pytorch/README.md
+++ b/script/get-ml-model-abtf-ssd-pytorch/README.md
@@ -40,6 +40,9 @@ mlcr get,ml-model,abtf-ssd-pytorch,ssd,resnet50,cmc
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--model_code_git_branch` |  |  | `cognata` |
 | `--model_code_git_url` |  |  | `https://github.com/mlcommons/abtf-ssd-pytorch` |
 ### Generic Script Inputs
@@ -95,4 +98,5 @@ mlcr get,ml-model,abtf-ssd-pytorch,ssd,resnet50,cmc
 
 ### Ungrouped
 
+- `service-account`
 - `skip_code`

--- a/script/get-ml-model-abtf-ssd-pytorch/meta.yaml
+++ b/script/get-ml-model-abtf-ssd-pytorch/meta.yaml
@@ -28,6 +28,16 @@ new_env_keys:
 input_mapping:
   model_code_git_branch: MLC_ABTF_MODEL_CODE_GIT_BRANCH
   model_code_git_url: MLC_ABTF_MODEL_CODE_GIT_URL
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Dependencies
 deps:
@@ -240,6 +250,9 @@ variations:
     adr:
       dae-ssd:
         tags: _r2-downloader
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
   skip_code:
     env:
       MLC_SKIP_MODEL_CODE_DOWNLOAD: 'yes'
@@ -257,5 +270,5 @@ tests:
   - variations_list:
     - onnx,rclone,mlc,dry-run
     - pytorch,rclone,mlc,dry-run
-    - onnx,r2-downloader,mlc,dry-run
-    - pytorch,r2-downloader,mlc,dry-run
+    - onnx,r2-downloader,mlc,dry-run,service-account
+    - pytorch,r2-downloader,mlc,dry-run,service-account

--- a/script/get-ml-model-deeplabv3_plus/README.md
+++ b/script/get-ml-model-deeplabv3_plus/README.md
@@ -36,7 +36,13 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,ml-model,deeplab,v3-plus,deeplabv3-plus
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -80,3 +86,4 @@ No script specific inputs
 ### Ungrouped
 
 - `dynamic`
+- `service-account`

--- a/script/get-ml-model-deeplabv3_plus/meta.yaml
+++ b/script/get-ml-model-deeplabv3_plus/meta.yaml
@@ -19,6 +19,19 @@ new_env_keys:
 - MLC_ML_MODEL_DEEPLABV3_PLUS_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
+
 # Variations
 variations:
   mlc:
@@ -120,6 +133,9 @@ variations:
     env:
       MLC_DOWNLOAD_EXTRA_OPTIONS: ' --include '
       MLC_DOWNLOAD_URL: mlc-cognata:mlc_cognata_dataset/<<<MLC_MODEL_RCLONE_FILEPATH>>>
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
 
 # Output / debugging
 print_env_at_the_end:
@@ -133,6 +149,6 @@ tests:
     - onnx,rclone,mlc,dry-run
     - onnx_dynamic,rclone,mlc,dry-run
     - pytorch,rclone,mlc,dry-run
-    - onnx,r2-downloader,mlc,dry-run
-    - onnx_dynamic,r2-downloader,mlc,dry-run
-    - pytorch,r2-downloader,mlc,dry-run
+    - onnx,r2-downloader,mlc,dry-run,service-account
+    - onnx_dynamic,r2-downloader,mlc,dry-run,service-account
+    - pytorch,r2-downloader,mlc,dry-run,service-account

--- a/script/get-ml-model-llama2/README.md
+++ b/script/get-ml-model-llama2/README.md
@@ -40,10 +40,10 @@ mlcr get,raw,ml-model,language-processing,llama2,llama2-70b,text-summarization
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--checkpoint` |  |  | `` |
-| `--client_id` |  |  | `` |
-| `--client_secret` |  |  | `` |
-| `--use_service_account` |  |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -124,6 +124,7 @@ mlcr get,raw,ml-model,language-processing,llama2,llama2-70b,text-summarization
 ### Ungrouped
 
 - `batch_size.#` _(# can be substituted dynamically)_
+- `service-account`
 
 ### Version
 

--- a/script/get-ml-model-llama2/meta.yaml
+++ b/script/get-ml-model-llama2/meta.yaml
@@ -31,9 +31,16 @@ new_env_keys:
 # Input mapping
 input_mapping:
   checkpoint: LLAMA2_CHECKPOINT_PATH
-  client_id: CF_ACCESS_CLIENT_ID
-  client_secret: CF_ACCESS_CLIENT_SECRET
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
   use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Dependencies
 prehook_deps:
@@ -323,6 +330,9 @@ variations:
         MLC_GIT_CHECKOUT_PATH_ENV_NAME: MLC_TENSORRT_LLM_CHECKOUT_PATH
       extra_cache_tags: tensorrt-llm
       tags: get,git,repo,_repo.https://github.com/NVIDIA/TensorRT-LLM.git,_branch.1.0-mlpinf,_sha.18c0333e96ea7a2c37caded8a310d05c5f095e88,_submodules.3rdparty/NVTX;3rdparty/cutlass;3rdparty/cxxopts;3rdparty/json;3rdparty/pybind11;3rdparty/ucxx;3rdparty/xgrammar
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
 
 # Docker / container
 docker:
@@ -337,5 +347,5 @@ tests:
   needs_pat: true
   run_inputs:
   - variations_list:
-    - r2-downloader,70b,mlc,dry-run
-    - r2-downloader,7b,mlc,dry-run
+    - r2-downloader,70b,mlc,dry-run,service-account
+    - r2-downloader,7b,mlc,dry-run,service-account

--- a/script/get-ml-model-llama3/README.md
+++ b/script/get-ml-model-llama3/README.md
@@ -40,6 +40,9 @@ mlcr get,raw,ml-model,language-processing,llama3,llama3-405b
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--outdirname` |  |  | `` |
 ### Generic Script Inputs
 
@@ -71,7 +74,6 @@ mlcr get,raw,ml-model,language-processing,llama3,llama3-405b
 ### Download-tool
 
 - `r2-downloader` (default)
-- `rclone`
 
 ### Framework
 
@@ -97,3 +99,7 @@ mlcr get,raw,ml-model,language-processing,llama3,llama3-405b
 ### Run-mode
 
 - `dry-run`
+
+### Ungrouped
+
+- `service-account`

--- a/script/get-ml-model-llama3/meta.yaml
+++ b/script/get-ml-model-llama3/meta.yaml
@@ -24,6 +24,16 @@ new_env_keys:
 # Input mapping
 input_mapping:
   outdirname: MLC_OUTDIRNAME
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Dependencies
 prehook_deps:
@@ -159,6 +169,9 @@ variations:
     adr:
       llama3-model-download:
         extra_cache_tags: llama3,dataset,r2-downloader
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
 
 # Docker / container
 docker:
@@ -173,5 +186,5 @@ tests:
   needs_pat: true
   run_inputs:
   - variations_list:
-    - r2-downloader,405b,mlc,dry-run
-    - r2-downloader,8b,mlc,dry-run
+    - r2-downloader,405b,mlc,dry-run,service-account
+    - r2-downloader,8b,mlc,dry-run,service-account

--- a/script/get-ml-model-pointpainting/README.md
+++ b/script/get-ml-model-pointpainting/README.md
@@ -40,6 +40,9 @@ mlcr get,ml-model,ml,model,pointpainting
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--dp_resnet50_path` |  |  | `` |
 | `--pp_path` |  |  | `` |
 ### Generic Script Inputs
@@ -81,3 +84,7 @@ mlcr get,ml-model,ml,model,pointpainting
 ### Run-mode
 
 - `dry-run`
+
+### Ungrouped
+
+- `service-account`

--- a/script/get-ml-model-pointpainting/meta.yaml
+++ b/script/get-ml-model-pointpainting/meta.yaml
@@ -23,6 +23,16 @@ new_env_keys:
 input_mapping:
   dp_resnet50_path: MLC_ML_MODEL_DPLAB_RESNET50_PATH
   pp_path: MLC_ML_MODEL_POINT_PAINTING_PATH
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Variations
 variations:
@@ -97,11 +107,14 @@ variations:
   rclone,mlc:
     env:
       MLC_DOWNLOAD_URL: mlc-waymo:waymo_preprocessed_dataset/model
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
 
 # Tests
 tests:
   needs_pat: true
   run_inputs:
   - variations_list:
-    - r2-downloader,mlc,dry-run
+    - r2-downloader,mlc,dry-run,service-account
     - rclone,mlc,dry-run

--- a/script/get-ml-model-yolov11/README.md
+++ b/script/get-ml-model-yolov11/README.md
@@ -36,7 +36,13 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get-ml-model-yolov11
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -70,3 +76,4 @@ No script specific inputs
 ### Ungrouped
 
 - `r2-downloader`
+- `service-account`

--- a/script/get-ml-model-yolov11/meta.yaml
+++ b/script/get-ml-model-yolov11/meta.yaml
@@ -15,6 +15,19 @@ new_env_keys:
 - MLC_ML_MODEL_YOLOV11_PATH
 - MLC_ML_MODEL_FILE_WITH_PATH
 
+# Input mapping
+input_mapping:
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
+
 # Variations
 variations:
   mlc:
@@ -54,6 +67,9 @@ variations:
           MLC_DOWNLOAD_URL: https://yolo.mlcommons-storage.org/metadata/YOLO-model.uri
         tags: _r2-downloader
     default: true
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
 
 # Output / debugging
 print_env_at_the_end:
@@ -64,4 +80,4 @@ tests:
   needs_pat: true
   run_inputs:
   - variations_list:
-    - r2-downloader,mlc,dry-run
+    - r2-downloader,mlc,dry-run,service-account

--- a/script/get-preprocessed-dataset-cognata/README.md
+++ b/script/get-preprocessed-dataset-cognata/README.md
@@ -36,7 +36,13 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,cognata,preprocessed
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -85,3 +91,7 @@ No script specific inputs
 
 - `2d_obj_det` (default)
 - `segmentation`
+
+### Ungrouped
+
+- `service-account`

--- a/script/get-preprocessed-dataset-cognata/meta.yaml
+++ b/script/get-preprocessed-dataset-cognata/meta.yaml
@@ -20,6 +20,19 @@ default_env:
 new_env_keys:
 - MLC_PREPROCESSED_DATASET_*
 
+# Input mapping
+input_mapping:
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
+
 # Variations
 variations:
   prebuilt:
@@ -123,6 +136,9 @@ variations:
   prebuilt,rclone:
     env:
       MLC_DOWNLOAD_EXTRA_OPTIONS: ' --include '
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
   validation,2d_obj_det:
     env:
       MLC_DATASET_COGNATA_EXTRACTED_FOLDER_NAME: val_2d
@@ -157,7 +173,7 @@ tests:
     - calibration,prebuilt,2d_obj_det,rclone,mlc,dry-run
     - validation,prebuilt,segmentation,rclone,mlc,dry-run
     - calibration,prebuilt,segmentation,rclone,mlc,dry-run
-    - validation,prebuilt,2d_obj_det,r2-downloader,mlc,dry-run
-    - calibration,prebuilt,2d_obj_det,r2-downloader,mlc,dry-run
-    - validation,prebuilt,segmentation,r2-downloader,mlc,dry-run
-    - calibration,prebuilt,segmentation,r2-downloader,mlc,dry-run
+    - validation,prebuilt,2d_obj_det,r2-downloader,mlc,dry-run,service-account
+    - calibration,prebuilt,2d_obj_det,r2-downloader,mlc,dry-run,service-account
+    - validation,prebuilt,segmentation,r2-downloader,mlc,dry-run,service-account
+    - calibration,prebuilt,segmentation,r2-downloader,mlc,dry-run,service-account

--- a/script/get-preprocessed-dataset-nuscenes/README.md
+++ b/script/get-preprocessed-dataset-nuscenes/README.md
@@ -36,7 +36,13 @@ mlc pull repo mlcommons@mlperf-automations --pat=<Your Private Access Token>
 mlcr get,dataset,nuscenes,preprocessed
 ```
 
-No script specific inputs
+### Script Inputs
+
+| Name | Description | Choices | Default |
+|------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -80,3 +86,7 @@ No script specific inputs
 ### Run-mode
 
 - `dry-run`
+
+### Ungrouped
+
+- `service-account`

--- a/script/get-preprocessed-dataset-nuscenes/meta.yaml
+++ b/script/get-preprocessed-dataset-nuscenes/meta.yaml
@@ -20,6 +20,19 @@ default_env:
 new_env_keys:
 - MLC_PREPROCESSED_DATASET_*
 
+# Input mapping
+input_mapping:
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
+
 # Variations
 variations:
   prebuilt:
@@ -106,6 +119,9 @@ variations:
   prebuilt,mlc,rclone:
     env:
       MLC_DOWNLOAD_EXTRA_OPTIONS: ' --include '
+  service-account:
+    env:
+      MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
   validation,mlc,r2-downloader:
     env:
       MLC_DOWNLOAD_URL: https://nuscenes.mlcommons-storage.org/metadata/nuscenes-dataset.uri
@@ -176,5 +192,5 @@ tests:
   - variations_list:
     - validation,prebuilt,rclone,mlc,dry-run
     - calibration,prebuilt,rclone,mlc,dry-run
-    - validation,prebuilt,r2-downloader,mlc,dry-run
-    - calibration,prebuilt,r2-downloader,mlc,dry-run
+    - validation,prebuilt,r2-downloader,mlc,dry-run,service-account
+    - calibration,prebuilt,r2-downloader,mlc,dry-run,service-account

--- a/script/run-mlperf-automotive-app/README.md
+++ b/script/run-mlperf-automotive-app/README.md
@@ -40,6 +40,9 @@ mlcr run-abtf,inference
 
 | Name | Description | Choices | Default |
 |------|-------------|---------|------|
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--backend` |  |  | `` |
 | `--batch_size` |  |  | `` |
 | `--category` |  |  | `` |

--- a/script/run-mlperf-automotive-app/meta.yaml
+++ b/script/run-mlperf-automotive-app/meta.yaml
@@ -69,6 +69,8 @@ input_mapping:
   precision: MLC_MLPERF_MODEL_PRECISION
   preprocess_submission: MLC_RUN_MLPERF_SUBMISSION_PREPROCESSOR
   push_to_github: MLC_MLPERF_RESULT_PUSH_TO_GITHUB
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
   readme: MLC_MLPERF_README
   regenerate_accuracy_file: MLC_MLPERF_REGENERATE_ACCURACY_FILE
   regenerate_files: MLC_REGENERATE_MEASURE_FILES
@@ -94,6 +96,14 @@ input_mapping:
   target_qps: MLC_MLPERF_LOADGEN_TARGET_QPS
   test_query_count: MLC_TEST_QUERY_COUNT
   threads: MLC_NUM_THREADS
+  use_service_account: MLC_AUTH_USING_SERVICE_ACCOUNT
+input_description:
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Dependencies
 deps:

--- a/script/run-mlperf-inference-app/README.md
+++ b/script/run-mlperf-inference-app/README.md
@@ -56,6 +56,8 @@ mlcr run-mlperf,inference
 | `--power` | Measure power | ['yes', 'no'] | `no` |
 | `--adr.mlperf-power-client.power_server` | MLPerf Power server IP address |  | `192.168.0.15` |
 | `--adr.mlperf-power-client.port` | MLPerf Power server port |  | `4950` |
+| `--r2_client_id` | Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
+| `--r2_client_secret` | Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line. |  | `` |
 | `--results_dir` | Alias for output_dir |  | `` |
 | `--use_dataset_from_host` | Run the dataset download script on the host machine and mount the dataset into the Docker container to avoid repeated downloads. | [True, False] | `no` |
 | `--use_model_from_host` | Run the model download script on the host machine and mount the model files into the Docker container to avoid repeated downloads. | [True, False] | `no` |
@@ -80,12 +82,11 @@ mlcr run-mlperf,inference
 | `--repro` | Record input/output/state/info files to make it easier to reproduce results |  | `False` |
 | `--time` | Print script execution time at the end of the run |  | `True` |
 | `--debug` | Debug this script |  | `False` |
+| `--use_service_account` | Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI. |  | `` |
 | `--all_models` |  |  | `` |
 | `--api_server` |  |  | `` |
 | `--batch_size` |  |  | `` |
 | `--beam_size` |  |  | `` |
-| `--client_id` |  |  | `` |
-| `--client_secret` |  |  | `` |
 | `--criteo_day23_raw_data_path` |  |  | `` |
 | `--custom_system_nvidia` |  |  | `` |
 | `--dashboard_wb_project` |  |  | `` |
@@ -101,6 +102,7 @@ mlcr run-mlperf,inference
 | `--gpu_name` |  |  | `` |
 | `--hw_notes_extra` |  |  | `` |
 | `--imagenet_path` |  |  | `` |
+| `--imagenet_preprocessed_path` |  |  | `` |
 | `--lang` | Alias for implementation |  | `` |
 | `--max_query_count` |  |  | `` |
 | `--max_test_duration` |  |  | `` |
@@ -117,6 +119,7 @@ mlcr run-mlperf,inference
 | `--output_tar` |  |  | `` |
 | `--performance_sample_count` |  |  | `` |
 | `--pip_loadgen` |  |  | `` |
+| `--podman_storage_root` |  |  | `` |
 | `--pointpainting_checkpoint_path` |  |  | `` |
 | `--preprocess_submission` |  |  | `` |
 | `--pull_changes` |  |  | `` |
@@ -142,11 +145,9 @@ mlcr run-mlperf,inference
 | `--test_query_count` |  |  | `` |
 | `--threads` |  |  | `` |
 | `--tp_size` |  |  | `` |
-| `--use_service_account` |  |  | `` |
 | `--vllm_model_name` |  |  | `` |
 | `--vllm_tp_size` |  |  | `1` |
 | `--waymo_path` |  |  | `` |
-| `--podman_storage_root` |  |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -183,7 +184,8 @@ mlcr run-mlperf,inference
 - `r5.1`
 - `r5.1-dev`
 - `r6.0`
-- `r6.0-dev` (default)
+- `r6.0-dev`
+- `r6.1-dev` (default)
 
 ### Mode
 

--- a/script/run-mlperf-inference-app/meta.yaml
+++ b/script/run-mlperf-inference-app/meta.yaml
@@ -48,8 +48,6 @@ input_mapping:
   beam_size: GPTJ_BEAM_SIZE
   category: MLC_MLPERF_SUBMISSION_SYSTEM_TYPE
   clean: MLC_MLPERF_CLEAN_ALL
-  client_id: CF_ACCESS_CLIENT_ID
-  client_secret: CF_ACCESS_CLIENT_SECRET
   compliance: MLC_MLPERF_LOADGEN_COMPLIANCE
   criteo_day23_raw_data_path: MLC_CRITEO_DAY23_RAW_DATA_PATH
   custom_system_nvidia: MLC_CUSTOM_SYSTEM_NVIDIA
@@ -93,6 +91,7 @@ input_mapping:
   output_tar: MLPERF_INFERENCE_SUBMISSION_TAR_FILE
   performance_sample_count: MLC_MLPERF_LOADGEN_PERFORMANCE_SAMPLE_COUNT
   pip_loadgen: MLC_MLPERF_INFERENCE_LOADGEN_INSTALL_FROM_PIP
+  podman_storage_root: MLC_PODMAN_STORAGE_ROOT
   pointpainting_checkpoint_path: MLC_ML_MODEL_POINT_PILLARS_PATH
   power: MLC_SYSTEM_POWER
   precision: MLC_MLPERF_MODEL_PRECISION
@@ -100,6 +99,8 @@ input_mapping:
   pull_changes: MLC_MLPERF_INFERENCE_PULL_CODE_CHANGES
   pull_inference_changes: MLC_MLPERF_INFERENCE_PULL_SRC_CHANGES
   push_to_github: MLC_MLPERF_RESULT_PUSH_TO_GITHUB
+  r2_client_id: CF_ACCESS_CLIENT_ID
+  r2_client_secret: CF_ACCESS_CLIENT_SECRET
   readme: MLC_MLPERF_README
   regenerate_accuracy_file: MLC_MLPERF_REGENERATE_ACCURACY_FILE
   regenerate_files: MLC_REGENERATE_MEASURE_FILES
@@ -135,7 +136,6 @@ input_mapping:
   vllm_model_name: MLC_VLLM_SERVER_MODEL_NAME
   vllm_tp_size: MLC_MLPERF_INFERENCE_TP_SIZE
   waymo_path: MLC_DATASET_WAYMO_PATH
-  podman_storage_root: MLC_PODMAN_STORAGE_ROOT
 input_description:
   division:
     choices:
@@ -216,6 +216,10 @@ input_description:
     - tvm-onnx
     desc: MLPerf framework (backend)
     sort: 400
+  r2_client_id:
+    desc: Cloudflare Access service-account client ID. Sets CF_ACCESS_CLIENT_ID for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
+  r2_client_secret:
+    desc: Cloudflare Access service-account client secret. Sets CF_ACCESS_CLIENT_SECRET for the r2-downloader; only used together with --use_service_account. Prefer exporting the variable instead of passing it on the command line.
   scenario:
     choices:
     - Offline
@@ -337,6 +341,8 @@ input_description:
     desc: Debug this script
     boolean: true
     default: false
+  use_service_account:
+    desc: Authenticate with Cloudflare Access using service-account credentials (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET) instead of an interactive browser login. Only used with the r2-downloader download tool; required to reach gated buckets on headless machines and in CI.
 
 # Dependencies
 predeps: false


### PR DESCRIPTION
## Summary

Model/dataset downloads from **gated** Cloudflare Access buckets fail in CI. The `mlc-r2-downloader.sh` `-s` flag switches it to service-account credentials, but no gated script could actually request it.

The failure is worse than a plain auth error: the downloader authenticates at [line 763](https://github.com/mlcommons/r2-downloader/blob/main/mlc-r2-downloader.sh#L763), **before** its `-x` dry-run exit at line 898. So even `_dry-run` tests attempt an interactive browser login, which on a headless runner hangs until the job times out — the affected jobs each burned ~18 minutes on `A browser window should have opened` before dying.

`download-file/customize.py` already emitted `-s` from `MLC_AUTH_USING_SERVICE_ACCOUNT`, but only `get-ml-model-llama2` and `run-mlperf-inference-app` declared an input mapping for it, so nothing else could reach it. CI has been exporting `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` in `run_tests_on_modified_meta_with_secrets.yml` the whole time — they were simply never used.

## Which buckets are gated

Probed all 48 `.uri` endpoints in `script/` using the downloader's own `check_auth_required` logic. The split is clean by host:

| Host | Status | Scripts |
|---|---|---|
| `cognata` | **gated** | `get-ml-model-abtf-ssd-pytorch`, `get-ml-model-deeplabv3_plus`, `get-preprocessed-dataset-cognata` |
| `llama2` | **gated** | `get-ml-model-llama2` |
| `llama3-1` | **gated** | `get-ml-model-llama3` |
| `nuscenes` | **gated** | `get-preprocessed-dataset-nuscenes` |
| `waymo` | **gated** | `get-dataset-waymo`, `get-dataset-waymo-calibration`, `get-ml-model-pointpainting` |
| `yolo` | **gated** | `get-ml-model-yolov11` |
| `inference` | public (all 29 URIs) | — |

## Changes

**`script/download-file/customize.py`** — validates `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` (from either the MLC env or the process env) before emitting `-s`, so a missing credential fails fast with an MLC-level error naming exactly what is absent, instead of failing deep inside the downloader. Warns and ignores when service-account auth is requested for a non-r2 tool, mirroring the existing handling of unsupported options.

**A new `service-account` variation** on `download-file`, `download-and-extract` and the 10 gated `get-*` scripts, plus `--use_service_account`, `--r2_client_id` and `--r2_client_secret` inputs. The variation sets `MLC_AUTH_USING_SERVICE_ACCOUNT`, which propagates wrapper → `download-and-extract` → `download-file` through normal env propagation, so no tag plumbing is needed.

**Test entries** — the `r2-downloader` entries of the 10 gated scripts now select `service-account`, so CI authenticates with the credentials it already exports.

**Renames** the pre-existing `--client_id` / `--client_secret` inputs on `get-ml-model-llama2` and `run-mlperf-inference-app` to `--r2_client_id` / `--r2_client_secret`, to make it clear they are r2-downloader specific.

## Test plan

Verified against the real endpoints and through the real mlc engine (not just unit-level):

- [x] `-s` is the correct flag — confirmed in `mlc-r2-downloader.sh` usage and by running it directly; `SERVICE_ACCOUNT: 1` with the exact flag shape MLC emits (`-d <path> -s -j 6 <url>`).
- [x] **Baseline reproduced:** without `-s`, a gated URL prints `Authentication required` then hangs on browser login — had to be killed. This is exactly the CI failure.
- [x] **Fixed:** `mlcr get-ml-model-yolov11,_mlc,_r2-downloader,_dry-run,_service-account` emits `... -x -s https://yolo.mlcommons-storage.org/...` and takes the service-account path, failing in seconds on deliberately-bad credentials rather than hanging.
- [x] Variation propagates through the full dep chain on `get-dataset-waymo`, `get-ml-model-llama2` (`_70b`), `get-preprocessed-dataset-cognata` (combined variations) and `get-ml-model-pointpainting`, each with its correct gated URL.
- [x] Credentials work by env var **and** via `--r2_client_id` / `--r2_client_secret` with no env set.
- [x] Missing credentials → `Error : service-account authentication was requested but the following are not set: ...`, naming only the ones actually absent.
- [x] Non-r2 tool (`_wget`) → warns, emits no `-s`.
- [x] **Without the variation the generated command is unchanged**, so nothing regresses for public buckets.
- [x] `mlc lint script` is stable on all 14 metas (second pass is a no-op); all `script/*/meta.yaml` parse.
- [x] `autopep8 -a` reports 15 hunks before and after — all pre-existing f-string lines, none added here.
- [x] READMEs regenerated with `mlc doc script <uid>`, the same command `document-scripts.yml` runs.

## Note on the remaining red checks

These gated jobs should now pass. Several **other** download tests are red for **pre-existing, unrelated** reasons that this PR does not address, and which touching these `meta.yaml` files makes CI surface:

- `get-ml-model-gptj`, `get-ml-model-rgat`, `get-ml-model-whisper`, `get-preprocessed-dataset-criteo`, `get-preprocessed-dataset-openorca` fail with `Multiple variation tags selected for the variation group "download-tool": {'r2-downloader', 'rclone'}` — their deps hardcode `_r2-downloader` while the test selects `rclone`.
- `get-dataset-whisper`, `get-ml-model-abtf-ssd-pytorch`, `get-ml-model-deeplabv3_plus`, `get-preprocessed-dataset-cognata`, `get-preprocessed-dataset-nuscenes` have rclone test indices that fail on rclone remote config / interactive rclone auth.

Happy to take those on in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
