### PR TITLE
remove rclone variation for pointpainting model

### DIFF
--- a/script/get-ml-model-pointpainting/meta.yaml
+++ b/script/get-ml-model-pointpainting/meta.yaml
@@ -75,21 +75,6 @@ variations:
       dae:
         tags: _r2-downloader
     default: true
-  rclone:
-    group: download-tool
-    add_deps_recursive:
-      dae:
-        tags: _rclone
-    prehook_deps:
-    - tags: get,rclone
-      enable_if_env:
-        MLC_TMP_REQUIRE_DOWNLOAD:
-        - true
-    - tags: get,rclone-config,_waymo
-      force_cache: true
-      enable_if_env:
-        MLC_TMP_REQUIRE_DOWNLOAD:
-        - true
   dry-run:
     group: run-mode
     env:
@@ -97,16 +82,10 @@ variations:
   dry-run,r2-downloader:
     env:
       MLC_DOWNLOAD_EXTRA_OPTIONS: -x
-  dry-run,rclone:
-    env:
-      MLC_DOWNLOAD_EXTRA_OPTIONS: --dry-run
   r2-downloader,mlc:
     env:
       MLC_DOWNLOAD_URL: https://waymo.mlcommons-storage.org/metadata/model.uri
       MLC_DOWNLOAD_FILENAME: model
-  rclone,mlc:
-    env:
-      MLC_DOWNLOAD_URL: mlc-waymo:waymo_preprocessed_dataset/model
   service-account:
     env:
       MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
@@ -117,4 +96,3 @@ tests:
   run_inputs:
   - variations_list:
     - r2-downloader,mlc,dry-run,service-account
-    - rclone,mlc,dry-run


### PR DESCRIPTION
Removes the `rclone` download-tool variation from `get-ml-model-pointpainting`, following the same approach as #1089 (whisper dataset).

Removed:
- the `rclone` variation (`add_deps_recursive` on `dae`, `get,rclone` and `get,rclone-config,_waymo` prehook deps)
- `dry-run,rclone` and `rclone,mlc` variation combinations
- the `rclone,mlc,dry-run` test case

`r2-downloader` was already `default: true` for the `download-tool` group, so the default behaviour is unchanged.

Verified that no other script requests this model via the rclone variation — both callers pin `_r2-downloader,_mlc`:
- `script/app-mlperf-inference/meta.yaml`: `get,ml-model,pointpainting,_r2-downloader,_mlc`
- `script/app-mlperf-inference-mlcommons-python/meta.yaml`: `get,ml-model,pointpainting,_r2-downloader,_mlc`

A repo-wide grep shows no remaining references combining pointpainting/pointpillars with rclone. The waymo dataset scripts keep their own rclone variations, so `get,rclone-config,_waymo` is untouched.

`mlc lint script --tags=get,ml-model,pointpainting` is clean, and `mlcr get,ml-model,ml,model,pointpainting,_r2-downloader,_mlc,_dry-run` resolves the variations and reaches the download step with the correct r2 URL (it then fails locally only because installing cloudflared needs sudo on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)