### PR TITLE
remove rclone variation for waymo dataset

### DIFF
--- a/script/get-dataset-waymo/meta.yaml
+++ b/script/get-dataset-waymo/meta.yaml
@@ -65,21 +65,6 @@ variations:
       dae:
         tags: _r2-downloader
     default: true
-  rclone:
-    group: download-tool
-    add_deps_recursive:
-      dae:
-        tags: _rclone
-    prehook_deps:
-    - tags: get,rclone
-      enable_if_env:
-        MLC_TMP_REQUIRE_DOWNLOAD:
-        - true
-    - tags: get,rclone-config,_waymo
-      force_cache: true
-      enable_if_env:
-        MLC_TMP_REQUIRE_DOWNLOAD:
-        - true
   dry-run:
     group: run-mode
     env:
@@ -87,16 +72,10 @@ variations:
   dry-run,r2-downloader:
     env:
       MLC_DOWNLOAD_EXTRA_OPTIONS: -x
-  dry-run,rclone:
-    env:
-      MLC_DOWNLOAD_EXTRA_OPTIONS: --dry-run
   r2-downloader,mlc:
     env:
       MLC_DOWNLOAD_URL: https://waymo.mlcommons-storage.org/metadata/dataset.uri
       MLC_DOWNLOAD_FILENAME: dataset
-  rclone,mlc:
-    env:
-      MLC_DOWNLOAD_URL: mlc_waymo:waymo_preprocessed_dataset/kitti_format
   service-account:
     env:
       MLC_AUTH_USING_SERVICE_ACCOUNT: 'yes'
@@ -107,4 +86,3 @@ tests:
   run_inputs:
   - variations_list:
     - r2-downloader,mlc,dry-run,service-account
-    - rclone,mlc,dry-run


### PR DESCRIPTION
Same pattern as #1089 (whisper), #1093 (pointpainting model) and #1094 (preprocessed cognata): drops the `rclone` download tool from `get-dataset-waymo`, leaving `r2-downloader` as the only one.

### Removed from `script/get-dataset-waymo/meta.yaml`
- the `rclone` variation — `_rclone` on the `dae` dep plus the `get,rclone` and `get,rclone-config,_waymo` prehook deps
- `dry-run,rclone` and `rclone,mlc` (the `mlc_waymo:waymo_preprocessed_dataset/kitti_format` URL)
- the `rclone,mlc,dry-run` entry from `tests.run_inputs`

22 deletions, no other file touched.

### Why this is safe
- `r2-downloader` already carried `default: true`, so default invocations are unchanged.
- Both callers already pin the r2 path: `app-mlperf-inference/meta.yaml:914` and `app-mlperf-inference-mlcommons-python/meta.yaml:573` request `get,dataset,waymo,_r2-downloader,_mlc`.
- `get-rclone-config`'s `_waymo` config stays — `get-dataset-waymo-calibration`, `get-ml-model-pointpainting` and `get-dataset-nuscenes` still reference it and are untouched here.

### Verification
- `mlc lint script --tags=get,dataset,waymo` — clean.
- Remaining variations: `kitti_format, mlc, r2-downloader, dry-run, dry-run,r2-downloader, r2-downloader,mlc, service-account`.
- `mlcr get,dataset,waymo,_mlc,_r2-downloader,_dry-run` resolves correctly and reaches the download step with the right URL (`https://waymo.mlcommons-storage.org/metadata/dataset.uri`) and the `-x` dry-run flag. It then fails locally inside the r2-downloader while updating `cloudflared` (`sudo: a terminal is required to read the password`) — an environment limitation on my machine, unrelated to this change, so no end-to-end download was completed.

The auto-generated `README.md` still lists `rclone` and is left for the docs regeneration, matching #1089.