### PR TITLE
Remove rclone variation for preprocessed openorca dataset

### DIFF
--- a/script/get-preprocessed-dataset-openorca/meta.yaml
+++ b/script/get-preprocessed-dataset-openorca/meta.yaml
@@ -115,11 +115,6 @@ variations:
         tags: _r2-downloader
     group: download-tool
     default: true
-  rclone:
-    add_deps_recursive:
-      dae-openorca:
-        tags: _rclone
-    group: download-tool
   nvidia:
     group: preprocess-step-provider
     env:
@@ -147,9 +142,6 @@ variations:
   dry-run,r2-downloader:
     env:
       MLC_DOWNLOAD_EXTRA_OPTIONS: -x
-  dry-run,rclone:
-    env:
-      MLC_DOWNLOAD_EXTRA_OPTIONS: --dry-run
   mlc:
     alias: mlcommons
   mlcommons:
@@ -171,7 +163,6 @@ variations:
         - MLC_DOWNLOAD_URL
     env:
       MLC_DATASET_PREPROCESSED_BY_MLC: 'yes'
-      MLC_RCLONE_URL: mlc-inference:mlcommons-inference-wg-public/open_orca
   nvidia,calibration:
     new_env_keys:
     - MLC_NVIDIA_PREPROCESSED_CALIBRATION_DATASET_PATH
@@ -181,10 +172,6 @@ variations:
   r2-downloader,mlcommons:
     env:
       MLC_DOWNLOAD_URL: https://inference.mlcommons-storage.org/metadata/llama-2-70b-open-orca-dataset.uri
-  rclone,mlcommons:
-    env:
-      MLC_DOWNLOAD_URL: mlc-inference:mlcommons-inference-wg-public/open_orca
-      MLC_RCLONE_CONFIG_NAME: mlc-inference
 
 # Docker / container
 docker:
@@ -196,4 +183,3 @@ tests:
   run_inputs:
   - variations_list:
     - r2-downloader,mlc,dry-run
-    - rclone,mlc,dry-run


### PR DESCRIPTION
## Summary

Same treatment as [#1089](https://github.com/mlcommons/mlperf-automations/pull/1089) (whisper), [#1093](https://github.com/mlcommons/mlperf-automations/pull/1093), [#1094](https://github.com/mlcommons/mlperf-automations/pull/1094) and [#1095](https://github.com/mlcommons/mlperf-automations/pull/1095), now for `get-preprocessed-dataset-openorca`.

`r2-downloader` is already `default: true` for this script's `download-tool` group and no caller passes `_rclone`, so removing the rclone path is behaviour-preserving.

## Changes

Single file, `script/get-preprocessed-dataset-openorca/meta.yaml` (14 deletions):

- the `rclone` download-tool variation (`_rclone` on the `dae-openorca` dep)
- `dry-run,rclone`
- `rclone,mlcommons` (`mlc-inference:mlcommons-inference-wg-public/open_orca` + `MLC_RCLONE_CONFIG_NAME`)
- `MLC_RCLONE_URL` in the `mlcommons` variation env — dead here: nothing in this script reads it (the download URL comes from `MLC_DOWNLOAD_URL` set in `r2-downloader,mlcommons`), and it is not in any `new_env_keys`, so it never propagated out. `get-ml-model-gptj` and `get-dataset-mlperf-inference-llama3` keep their own `MLC_RCLONE_URL`, which they do consume via `<<<MLC_RCLONE_URL>>>`.
- the `rclone,mlc,dry-run` test entry

Remaining variations: `calibration, validation, r2-downloader, nvidia, dry-run, 60, full, size.#, dry-run,r2-downloader, mlc, mlcommons, nvidia,calibration, nvidia,validation, r2-downloader,mlcommons`.

## Test plan

- [x] No caller depends on the rclone path — every consumer (`app-mlperf-inference`, `app-mlperf-inference-amd`, `get-ml-model-llama2`, `process-mlperf-accuracy`) requests `_mlc`/`_mlcommons` with no download-tool variation, and `grep` finds no `_rclone` alongside these tags anywhere in `script/`.
- [x] `mlc test script 5614c39cb1564d72 --test_input_index=1 --quiet` — the CI job for this script — exits 0, resolving `download-and-extract,_r2-downloader,_url.https://inference.mlcommons-storage.org/metadata/llama-2-70b-open-orca-dataset.uri`.
- [x] Without any download-tool variation (`mlcr get,dataset,openorca,language-processing,preprocessed,_mlc,_dry-run`) the default still resolves to the same r2 URL, exit 0.
- [x] `mlc lint script --tags=get,dataset,openorca,language-processing,preprocessed` clean, no churn.
- [x] YAML parses; `grep -i rclone` on the script directory returns nothing outside the auto-generated `README.md`, which is left for the docs regeneration job as in #1089.

## Note

The CI failure on this script in [#1086](https://github.com/mlcommons/mlperf-automations/pull/1086) (`Multiple variation tags selected for the variation group "download-tool"`) was an unrelated engine bug — per-run state leaking between the two entries of `variations_list` — fixed separately in [mlcommons/mlcflow#317](https://github.com/mlcommons/mlcflow/pull/317). This PR removes one of those two entries, but the two changes are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
