### PR TITLE
Skip interactive rclone auth in dry-run for abtf ssd model

### DIFF
--- a/script/get-ml-model-abtf-ssd-pytorch/meta.yaml
+++ b/script/get-ml-model-abtf-ssd-pytorch/meta.yaml
@@ -212,6 +212,7 @@ variations:
     group: run-mode
     env:
       MLC_DOWNLOAD_MODE: dry
+      MLC_BYPASS_RCLONE_AUTH: true
   abtf-poc,gdown:
     env:
       MLC_ML_MODEL_URL: https://drive.google.com/uc?id=1kfJR_bs54KONprVd51kZu0PYmmh1wZZa


### PR DESCRIPTION
## Problem

The `get-ml-model-abtf-ssd-pytorch` job in the "Test script on modified meta (with secret)" workflow dies at the first test entry, `onnx,rclone,mlc,dry-run` ([example](https://github.com/mlcommons/mlperf-automations/actions/runs/33854583394/job/101130146214)):

```
* mlcr get,rclone-config,_config-name.mlc-cognata
Running:
rclone config create mlc-cognata drive config_is_local=false scope=drive.readonly root_folder_id=1u5F... && rclone config reconnect mlc-cognata:

Use web browser to automatically authenticate rclone with remote?
y) Yes (default)
Failed to read line: EOF
Error : Native run script failed inside MLC script (name = get-rclone-config, return code = 256)
```

`rclone config reconnect` is an interactive Google Drive OAuth prompt. There is no TTY on a runner, so it fails at the prompt.

This is not caught by the ABTF POC workflow, which passes: that flow uses `_abtf-poc`, whose `default_variations: {download-tool: gdown}` fetches the model from a public Google Drive share link (`download,file,_gdown,_url.https://drive.google.com/uc?id=1kfJR...`). It never sets `_mlc`, so the `download-and-extract` prehook and `get,rclone-config` are never reached. Different source, different code path.

## Change

`get-rclone-config` already guards the reconnect:

https://github.com/mlcommons/mlperf-automations/blob/60d0eb2/script/get-rclone-config/customize.py#L22-L24

```python
if env.get('MLC_RCLONE_CONNECT_CMD', '') != '' and not is_true(
        env.get('MLC_BYPASS_RCLONE_AUTH', '')):
    run_cmds.append(env['MLC_RCLONE_CONNECT_CMD'])
```

`get-dataset-waymo-calibration` is the only script that sets it, on its `dry-run` variation. This applies the same one-liner to `get-ml-model-abtf-ssd-pytorch`, keeping the scope identical: real downloads still do the interactive reconnect, only dry-runs skip it.

## Test plan

- [x] `mlcr get,ml-model,abtf-ssd-pytorch,_onnx,_rclone,_mlc,_dry-run` with caches cleared now emits `Running: rclone config create mlc-cognata drive ...` with **no** `&& rclone config reconnect`, no prompt, and proceeds to `download-and-extract,_rclone,_url.mlc-cognata:mlc_cognata_dataset/model_checkpoint_ssd/ssd_resnet50.onnx`. On `main` the same command stops at the browser prompt.
- [x] `mlc lint script --tags=get,ml-model,abtf-ssd-pytorch` clean.
- [x] The `_gdown` path used by the ABTF POC workflow is untouched — this only adds an env key to the `dry-run` variation.

## This is necessary but not sufficient for a green job

Flagging two further blockers found while verifying, both outside this change:

**1. The service-account credentials env var never reaches the `mlc-cognata` remote.** The workflow exports `RCLONE_CONFIG_MLC_COGNATA_SERVICE_ACCOUNT_CREDENTIALS`, but rclone does *not* translate `-` to `_` when matching a remote name to its env override. Reproduced on rclone v1.70.2 against the real remote:

```
$ RCLONE_CONFIG_MLC_COGNATA_SERVICE_ACCOUNT_FILE=/tmp/sa.json rclone lsd mlc-cognata:
CRITICAL: ... failed to create oauth client: empty token found - please run "rclone config reconnect mlc-cognata:"

$ env "RCLONE_CONFIG_MLC-COGNATA_SERVICE_ACCOUNT_FILE=/tmp/sa.json" rclone lsd mlc-cognata:
CRITICAL: ... failed to create oauth client from service account: error processing credentials: ...
```

The second form reaches the service account (it then fails only because that test file holds a deliberately invalid key). So the variable needs the literal hyphen — `RCLONE_CONFIG_MLC-COGNATA_SERVICE_ACCOUNT_CREDENTIALS` — or the remote needs renaming to `mlc_cognata` in `get-rclone-config`. The same applies to `RCLONE_CONFIG_MLC_NUSCENES_SERVICE_ACCOUNT_CREDENTIALS`. Until then, the transfer fails right after the config step with `empty token found`, which is exactly what happens locally without credentials.

**2. The 4-entry `variations_list` hits the engine state leak** fixed in [mlcommons/mlcflow#317](https://github.com/mlcommons/mlcflow/pull/317): `add_deps_recursive` from the `_rclone` entries survives into the `_r2-downloader` entries, producing `Multiple variation tags selected for the variation group "download-tool"`.

Happy to follow up on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
