### PR TITLE
Fix rclone service-account credentials never reaching drive remotes

### DIFF
--- a/.github/workflows/run_tests_on_modified_meta_with_secrets.yml
+++ b/.github/workflows/run_tests_on_modified_meta_with_secrets.yml
@@ -59,9 +59,22 @@ jobs:
   
       - name: Set RCLONE Service account env var from secret
         shell: bash
+        env:
+          GDRIVE_SERVICE_ACCOUNT_KEY: ${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}
         run: |
-          echo "RCLONE_CONFIG_MLC_COGNATA_SERVICE_ACCOUNT_CREDENTIALS=${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}" >> $GITHUB_ENV
-          echo "RCLONE_CONFIG_MLC_NUSCENES_SERVICE_ACCOUNT_CREDENTIALS=${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}" >> $GITHUB_ENV
+          # rclone matches a remote to its RCLONE_CONFIG_<remote>_<option>
+          # override using the remote's exact name and does not translate "-"
+          # to "_", so RCLONE_CONFIG_MLC_COGNATA_* never reached the
+          # "mlc-cognata" remote and rclone fell back to interactive OAuth.
+          # The backend-wide variable applies to every drive remote
+          # (mlc-cognata, mlc-llama2, mlc_waymo, ...) and avoids the name
+          # mapping entirely. Non-drive remotes such as the mlc-inference S3
+          # config are unaffected.
+          {
+            echo "RCLONE_DRIVE_SERVICE_ACCOUNT_CREDENTIALS<<MLC_EOF_SA"
+            echo "$GDRIVE_SERVICE_ACCOUNT_KEY"
+            echo "MLC_EOF_SA"
+          } >> "$GITHUB_ENV"
 
       - name: Set r2-downloader Service account env var from secret
         shell: bash

--- a/.github/workflows/test-mlperf-automotive.yml
+++ b/.github/workflows/test-mlperf-automotive.yml
@@ -22,9 +22,22 @@ jobs:
           GDRIVE_SERVICE_ACCOUNT_KEY: op://7basd2jirojjckncf6qnq3azai/bzbaco3uxoqs2rcyu42rvuccga/credential
       - name: Set RCLONE Service account env var from secret
         shell: bash
+        env:
+          GDRIVE_SERVICE_ACCOUNT_KEY: ${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}
         run: |
-          echo "RCLONE_CONFIG_MLC_COGNATA_SERVICE_ACCOUNT_CREDENTIALS=${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}" >> $GITHUB_ENV
-          echo "RCLONE_CONFIG_MLC_NUSCENES_SERVICE_ACCOUNT_CREDENTIALS=${{ steps.op-load-secrets.outputs.GDRIVE_SERVICE_ACCOUNT_KEY }}" >> $GITHUB_ENV
+          # rclone matches a remote to its RCLONE_CONFIG_<remote>_<option>
+          # override using the remote's exact name and does not translate "-"
+          # to "_", so RCLONE_CONFIG_MLC_COGNATA_* never reached the
+          # "mlc-cognata" remote and rclone fell back to interactive OAuth.
+          # The backend-wide variable applies to every drive remote
+          # (mlc-cognata, mlc-llama2, mlc_waymo, ...) and avoids the name
+          # mapping entirely. Non-drive remotes such as the mlc-inference S3
+          # config are unaffected.
+          {
+            echo "RCLONE_DRIVE_SERVICE_ACCOUNT_CREDENTIALS<<MLC_EOF_SA"
+            echo "$GDRIVE_SERVICE_ACCOUNT_KEY"
+            echo "MLC_EOF_SA"
+          } >> "$GITHUB_ENV"
       - name: Run MLPerf
         shell: bash
         env:


### PR DESCRIPTION
## Problem

With [#1097](https://github.com/mlcommons/mlperf-automations/pull/1097) applied, the `get-ml-model-abtf-ssd-pytorch` job gets past the interactive OAuth prompt but still fails ([run](https://github.com/mlcommons/mlperf-automations/actions/runs/33912331878/job/101151423274)):

```
* mlcr get,rclone-config,_config-name.mlc-cognata
rclone config create mlc-cognata drive config_is_local=false scope=drive.readonly root_folder_id=1u5F...     <- no reconnect, prompt gone
...
Downloading: rclone sync 'mlc-cognata:mlc_cognata_dataset/model_checkpoint_ssd/ssd_resnet50.onnx' ...
Failed to create file system: drive: failed when making oauth client: empty token found - please run "rclone config reconnect mlc-cognata:"
```

The credential is present in the job environment (`RCLONE_CONFIG_MLC_COGNATA_SERVICE_ACCOUNT_CREDENTIALS: ***` at the top of the log), yet rclone behaves as if no credentials were given.

## Root cause

rclone matches a remote to its `RCLONE_CONFIG_<remote>_<option>` override using the remote's **exact name**, and does not translate `-` to `_`. So `RCLONE_CONFIG_MLC_COGNATA_...` addresses a remote called `mlc_cognata`. The remote `get-rclone-config` actually creates is `mlc-cognata`, so the override never applied and rclone fell back to OAuth, where there is no token.

Reproduced against the real remote on rclone v1.70.2:

```
$ RCLONE_CONFIG_MLC_COGNATA_SERVICE_ACCOUNT_FILE=/tmp/sa.json rclone lsd mlc-cognata:
CRITICAL: ... empty token found - please run "rclone config reconnect mlc-cognata:"

$ env "RCLONE_CONFIG_MLC-COGNATA_SERVICE_ACCOUNT_FILE=/tmp/sa.json" rclone lsd mlc-cognata:
CRITICAL: ... failed to create oauth client from service account: error processing credentials: ...
```

Only the literal-hyphen form reaches the service account. `RCLONE_CONFIG_MLC_NUSCENES_*` is dead for the same reason — the remote `get-ml-model-bevformer` creates is `mlc-nuscenes`, also hyphenated.

## Fix

The spelling is only half the problem. Per-remote variables also have to be *enumerated* and kept in sync with the metas, and they were not:

| drive remote | created by | credentials var on `main` | reached rclone? |
|---|---|---|---|
| `mlc-cognata` | `_config-name.mlc-cognata` | `RCLONE_CONFIG_MLC_COGNATA_*` | no — hyphen |
| `mlc-nuscenes` | `_config-name.mlc-nuscenes` | `RCLONE_CONFIG_MLC_NUSCENES_*` | no — hyphen |
| `mlc-llama2` | `_mlperf-llama2` | none | no |
| `mlc-llama3-1` | `_mlperf-llama3-1` | none | no |
| `mlc_waymo` | `_waymo` | none | no |
| `cognata` | `_config-name.cognata` | none | no |

Six drive remotes, two variables listed, zero effective. Note `mlc_waymo` is already underscore-clean — renaming remotes would not have covered it, because it was simply never added.

So export the backend-wide `RCLONE_DRIVE_SERVICE_ACCOUNT_CREDENTIALS` instead. It applies to every drive remote regardless of how the name is spelled or whether anyone remembered to add it, and it cannot drift out of sync as remotes are added. Non-drive remotes, i.e. the `mlc-inference` Cloudflare S3 config, are untouched.

Also switched to the `GITHUB_ENV` heredoc form and moved the secret into the step's `env:` block. A service-account key is JSON and may be pretty-printed; `echo "NAME=$value" >> $GITHUB_ENV` corrupts the file at the first newline. This was latent while the variable was dead.

Applied to both workflows that set these: `run_tests_on_modified_meta_with_secrets.yml` and `test-mlperf-automotive.yml`.

## Test plan

Verified locally against the real `mlc-cognata` remote (rclone v1.70.2), using a syntactically valid service-account JSON with a dummy private key:

- [x] **With** `RCLONE_DRIVE_SERVICE_ACCOUNT_CREDENTIALS`, rclone builds the service-account client, resolves folder id `1u5FDoeXHVtDrd4zClE47Gmyr7iLFidz1` and issues the real Drive API request, failing only on the dummy key: `private key should be a PEM or plain PKCS1 or PKCS8`. With the genuine key this call succeeds.
- [x] **Without** it — today's CI — the same command dies earlier at `empty token found`, matching the CI log exactly.
- [x] Simulated the full `GITHUB_ENV` round-trip with a pretty-printed multi-line JSON secret: the heredoc form writes and parses back byte-identical, and rclone consumes the parsed value. The previous `echo NAME=$value` form would have produced a malformed `GITHUB_ENV`.
- [x] Both workflow files parse as YAML; CRLF line endings in `test-mlperf-automotive.yml` preserved.

## Remaining blocker for a fully green job

`get-ml-model-abtf-ssd-pytorch` has four entries in one `variations_list`, which trips the engine state leak fixed in [mlcommons/mlcflow#317](https://github.com/mlcommons/mlcflow/pull/317) — `add_deps_recursive` from the `_rclone` entries survives into the `_r2-downloader` entries, giving `Multiple variation tags selected for the variation group "download-tool"`. That fix is independent of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
