### PR TITLE
Enchancement - addition of training wg sysinfo format

### DIFF
--- a/script/get-mlperf-multi-node-system-info/README.md
+++ b/script/get-mlperf-multi-node-system-info/README.md
@@ -47,6 +47,9 @@ mlcr get-mlperf-multi-node-system-info
 | `--dataset_name` |  |  | `` |
 | `--dataset_type` |  |  | `` |
 | `--division` |  |  | `` |
+| `--framework` |  |  | `` |
+| `--framework_name` |  |  | `` |
+| `--host_networking_topology` |  |  | `` |
 | `--hw_notes` |  |  | `` |
 | `--input_token_average` |  |  | `` |
 | `--link_to_dataset` |  |  | `` |
@@ -62,7 +65,8 @@ mlcr get-mlperf-multi-node-system-info
 | `--output_token_average` |  |  | `` |
 | `--skip_ssh_key_file` |  |  | `` |
 | `--ssh_ids` |  |  | `` |
-| `--status` |  |  | `` |
+| `--sw_notes` |  |  | `` |
+| `--system_availability_status` |  |  | `` |
 | `--submitter_contact` |  |  | `` |
 | `--submitter_org_name` |  |  | `` |
 | `--node_config_file` |  |  | `` |
@@ -78,6 +82,10 @@ mlcr get-mlperf-multi-node-system-info
 | `--log_path` |  |  | `/tmp/serving.log` |
 | `--run_metadata_path` |  |  | `` |
 | `--serving_framework_type` |  |  | `` |
+| `--system_type_detail` |  |  | `` |
+| `--redfish_endpoint` |  |  | `` |
+| `--redfish_username` |  |  | `` |
+| `--redfish_password` |  |  | `` |
 ### Generic Script Inputs
 
 | Name | Description | Choices | Default |
@@ -106,6 +114,16 @@ mlcr get-mlperf-multi-node-system-info
 - `rocm`
 - `xpu`
 
+### Mlperf-benchmark
+
+- `endpoints`
+- `inference`
+- `training`
+
 ### Ungrouped
 
 - `exclude_current_node`
+- `inference_optional_nameplate`
+- `network`
+- `power`
+- `redfish`

--- a/script/get-mlperf-multi-node-system-info/customize.py
+++ b/script/get-mlperf-multi-node-system-info/customize.py
@@ -38,6 +38,10 @@ _CONFIG_KEY_TO_ENV = {
     "container_link": "MLC_MLPERF_CONTAINER_LINK",
     "measured_accuracy_score": "MLC_MLPERF_MEASURED_ACCURACY_SCORE",
     "system_type_detail": "MLC_MLPERF_SYSTEM_TYPE_DETAIL",
+    "framework": "MLC_MLPERF_FRAMEWORK",
+    "framework_name": "MLC_MLPERF_FRAMEWORK_NAME",
+    "sw_notes": "MLC_MLPERF_SOFTWARE_NOTES",
+    "host_networking_topology": "MLC_MLPERF_HOST_NETWORKING_TOPOLOGY",
 }
 
 
@@ -477,6 +481,29 @@ def _merge_heterogeneous_nodes(node_types):
     return merged
 
 
+def _lift_hardware(nested_info):
+    """Collapse node_types into a single flat hardware dict + total node count.
+
+    Homogeneous systems lift node 0 verbatim; heterogeneous ones comma-separate
+    unique values per field. Shared by the inference and training flatteners.
+    """
+    node_types = nested_info.get("node_types", [])
+    total_nodes = nested_info.get(
+        "system_node_ensemble_total",
+        sum(nt.get("number_of_nodes", 1) for nt in node_types),
+    )
+
+    if not node_types:
+        hw = {}
+    elif _is_homogeneous(node_types):
+        hw = {k: v for k, v in node_types[0].items(
+        ) if k not in _NODE_METADATA_FIELDS}
+    else:
+        hw = _merge_heterogeneous_nodes(node_types)
+
+    return hw, total_nodes
+
+
 def _flatten_for_inference(nested_info, env):
     """
     Convert the nested node_types format to a flat dict compatible with the
@@ -492,19 +519,7 @@ def _flatten_for_inference(nested_info, env):
     All fields required by SYSTEM_DESC_REQUIRED_FIELDS in constants.py are present;
     those not auto-captured are set to empty string.
     """
-    node_types = nested_info.get("node_types", [])
-    total_nodes = nested_info.get(
-        "system_node_ensemble_total",
-        sum(nt.get("number_of_nodes", 1) for nt in node_types),
-    )
-
-    if not node_types:
-        hw = {}
-    elif _is_homogeneous(node_types):
-        hw = {k: v for k, v in node_types[0].items(
-        ) if k not in _NODE_METADATA_FIELDS}
-    else:
-        hw = _merge_heterogeneous_nodes(node_types)
+    hw, total_nodes = _lift_hardware(nested_info)
 
     def _hw(key):
         """Return hw[key] as str, or '' when absent, None, 'Not available', or 'N/A'."""
@@ -539,7 +554,9 @@ def _flatten_for_inference(nested_info, env):
         "host_memory_configuration": _hw("host_memory_configuration"),
         # Host networking
         "host_networking": _hw("host_networking"),
-        "host_networking_topology": "",  # requires manual input
+        # Not auto-detectable; empty unless --host_networking_topology is
+        # given.
+        "host_networking_topology": env.get("MLC_MLPERF_HOST_NETWORKING_TOPOLOGY", ""),
         "host_network_card_count": _hw("host_network_card_count"),
         # Accelerator
         "accelerator_model_name": _hw("accelerator_model_name"),
@@ -557,7 +574,7 @@ def _flatten_for_inference(nested_info, env):
         "other_software_stack": _hw("other_software_stack"),
         # Notes / other
         "hw_notes": _hw("hw_notes"),
-        "sw_notes": _hw("sw_notes"),
+        "sw_notes": env.get("MLC_MLPERF_SOFTWARE_NOTES", "") or _hw("sw_notes"),
         "other_hardware": _hw("other_hardware"),
         "cooling": _hw("cooling"),
         "system_type_detail": env.get("MLC_MLPERF_SYSTEM_TYPE_DETAIL", ""),
@@ -570,6 +587,237 @@ def _flatten_for_inference(nested_info, env):
         flat.update({f: "" for f in _POWER_EXTRA_FIELDS if f not in flat})
 
     return flat
+
+
+# ── Training flat-format helpers ────────────────────────────────────────
+
+# The four availability strings the training system_desc_checker accepts for
+# ruleset >= 4.1 (availability_options in
+# mlperf_logging/system_desc_checker/system_desc_checker.py). Anything else
+# fails the checker outright, so we validate here rather than let a submitter
+# find out at submission time.
+_TRAINING_STATUS_OPTIONS = [
+    "Available on-premise",
+    "Available cloud",
+    "Research, Development, or Internal (RDI)",
+    "Preview",
+]
+
+# Lower-cased shorthands accepted for --system_availability_status, on top of the canonical
+# spellings above. Bare "available" is deliberately absent: it is the value
+# MLPerf Inference uses, but training splits it into on-premise vs cloud and
+# guessing which one a submitter meant would silently mislabel a submission.
+_TRAINING_STATUS_ALIASES = {
+    "on-premise": "Available on-premise",
+    "on-prem": "Available on-premise",
+    "onprem": "Available on-premise",
+    "available on-prem": "Available on-premise",
+    "available onprem": "Available on-premise",
+    "cloud": "Available cloud",
+    "rdi": "Research, Development, or Internal (RDI)",
+    "research, development, or internal": "Research, Development, or Internal (RDI)",
+    "internal": "Research, Development, or Internal (RDI)",
+}
+
+
+def _normalize_training_status(status):
+    """Map a user-supplied availability string onto one of the four values the
+    training system_desc_checker accepts.
+
+    Returns (value, None) on success or (None, error_message) on failure.
+    """
+    raw = (status or "").strip()
+    if not raw:
+        return "", None
+
+    lowered = raw.lower()
+    for option in _TRAINING_STATUS_OPTIONS:
+        if lowered == option.lower():
+            return option, None
+    if lowered in _TRAINING_STATUS_ALIASES:
+        return _TRAINING_STATUS_ALIASES[lowered], None
+
+    hint = ""
+    if lowered in ("available", "avail"):
+        hint = (" MLPerf Training splits availability into on-premise and "
+                "cloud, so 'available' is ambiguous -- pick one explicitly.")
+    return None, (
+        f"status '{raw}' is not valid for MLPerf Training. It must be one of "
+        f"{_TRAINING_STATUS_OPTIONS}.{hint}"
+    )
+
+
+# Field order of the training system description, matching required_fields in
+# mlperf_logging/system_desc_checker/system_desc_checker.py. The checker only
+# tests for presence, but keeping the published order makes the generated file
+# diffable against existing submissions in the training_results repos.
+_TRAINING_FIELD_ORDER = [
+    "submitter",
+    "division",
+    "status",
+    "system_name",
+    "number_of_nodes",
+    "host_processors_per_node",
+    "host_processor_model_name",
+    "host_processor_core_count",
+    "host_processor_vcpu_count",
+    "host_processor_frequency",
+    "host_processor_caches",
+    "host_processor_interconnect",
+    "host_memory_capacity",
+    "host_storage_type",
+    "host_storage_capacity",
+    "host_networking",
+    "host_networking_topology",
+    "host_memory_configuration",
+    "accelerators_per_node",
+    "accelerator_model_name",
+    "accelerator_host_interconnect",
+    "accelerator_frequency",
+    "accelerator_on-chip_memories",
+    "accelerator_memory_configuration",
+    "accelerator_memory_capacity",
+    "accelerator_interconnect",
+    "accelerator_interconnect_topology",
+    "cooling",
+    "hw_notes",
+    "framework",
+    "framework_name",
+    "other_software_stack",
+    "operating_system",
+    "sw_notes",
+]
+
+
+def _training_value(value):
+    """Coerce one field to the string form training submissions use.
+
+    Every value in a training system description is a string -- counts
+    included ("8", not 8). Detection-failure markers ("N/A", "Not available",
+    "Not detected: ...") become the empty string, which is how existing
+    submissions express "not disclosed".
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        stripped = value.strip()
+        if (stripped in ("N/A", "Not available")
+                or stripped.lower().startswith("not detected")):
+            return ""
+        return stripped
+    return str(value)
+
+
+def _flatten_for_training(nested_info, env, logger):
+    """
+    Convert the nested node_types format to the flat JSON the MLPerf Training
+    system_desc_checker validates (mlcommons/logging, usage="training").
+
+    Field name remappings applied at the top level:
+      submitter_org_names        -> submitter
+      system_availability_status -> status  (normalized to the four legal values)
+
+    `framework` is NOT the inference `serving_framework`: for training it is
+    the training framework and version (e.g. "NVIDIA PyTorch Release 25.04"),
+    supplied via --framework. `framework_name` is an optional extra field some
+    submitters carry (e.g. "ngc25.04_pytorch"); it is emitted only when set.
+
+    Node-level hardware fields are lifted verbatim (no renames). Every field in
+    the checker's required_fields list is present; those not auto-captured are
+    empty strings, which the checker accepts.
+
+    Returns (flat_dict, None) on success or (None, error_message) on failure.
+    """
+    # Normalize each node's values BEFORE lifting, not after. On a
+    # heterogeneous system _merge_heterogeneous_nodes comma-joins the per-node
+    # values, so a single node's "Not detected: ..." marker would otherwise
+    # contaminate the merged string and blank out the real values its peers
+    # did detect.
+    cleaned = dict(nested_info)
+    cleaned["node_types"] = [
+        {k: (v if k in _NODE_METADATA_FIELDS else _training_value(v))
+         for k, v in nt.items()}
+        for nt in nested_info.get("node_types", [])
+    ]
+    hw, total_nodes = _lift_hardware(cleaned)
+
+    def _hw(key):
+        return hw.get(key, "")
+
+    status, err = _normalize_training_status(
+        nested_info.get("system_availability_status", ""))
+    if err:
+        return None, err
+
+    division = _training_value(nested_info.get("division", "")).lower()
+    if division and division not in ("closed", "open"):
+        logger.warning(
+            "division '%s' is not 'closed' or 'open' -- the training package "
+            "checker keys off those two values.", division)
+
+    framework = _training_value(env.get("MLC_MLPERF_FRAMEWORK", ""))
+    if not framework:
+        logger.warning(
+            "No --framework given. MLPerf Training expects the training "
+            "framework and version here (e.g. \"NVIDIA PyTorch Release "
+            "25.04\"); the field is being written empty.")
+
+    flat = {
+        # Identity / submitter
+        "submitter": _training_value(nested_info.get("submitter_org_names", "")),
+        "division": division,
+        "status": status,
+        "system_name": _training_value(nested_info.get("system_name", "")),
+        # Multi-node count
+        "number_of_nodes": _training_value(total_nodes),
+        # Host CPU
+        "host_processors_per_node": _hw("host_processors_per_node"),
+        "host_processor_model_name": _hw("host_processor_model_name"),
+        "host_processor_core_count": _hw("host_processor_core_count"),
+        "host_processor_vcpu_count": _hw("host_processor_vcpu_count"),
+        "host_processor_frequency": _hw("host_processor_frequency"),
+        "host_processor_caches": _hw("host_processor_caches"),
+        "host_processor_interconnect": _hw("host_processor_interconnect"),
+        # Host memory / storage
+        "host_memory_capacity": _hw("host_memory_capacity"),
+        "host_storage_type": _hw("host_storage_type"),
+        "host_storage_capacity": _hw("host_storage_capacity"),
+        # Host networking
+        "host_networking": _hw("host_networking"),
+        # Not auto-detectable; empty unless --host_networking_topology is
+        # given.
+        "host_networking_topology": _training_value(
+            env.get("MLC_MLPERF_HOST_NETWORKING_TOPOLOGY", "")),
+        "host_memory_configuration": _hw("host_memory_configuration"),
+        # Accelerator
+        "accelerators_per_node": _hw("accelerators_per_node"),
+        "accelerator_model_name": _hw("accelerator_model_name"),
+        "accelerator_host_interconnect": _hw("accelerator_host_interconnect"),
+        "accelerator_frequency": _hw("accelerator_frequency"),
+        "accelerator_on-chip_memories": _hw("accelerator_on-chip_memories"),
+        "accelerator_memory_configuration": _hw("accelerator_memory_configuration"),
+        "accelerator_memory_capacity": _hw("accelerator_memory_capacity"),
+        "accelerator_interconnect": _hw("accelerator_interconnect"),
+        "accelerator_interconnect_topology": _hw("accelerator_interconnect_topology"),
+        # Notes / other hardware
+        "cooling": _hw("cooling"),
+        "hw_notes": _hw("hw_notes"),
+        # Software
+        "framework": framework,
+        "other_software_stack": _hw("other_software_stack"),
+        "operating_system": _hw("operating_system"),
+        "sw_notes": _training_value(env.get("MLC_MLPERF_SOFTWARE_NOTES", ""))
+        or _hw("sw_notes"),
+    }
+
+    framework_name = _training_value(env.get("MLC_MLPERF_FRAMEWORK_NAME", ""))
+    if framework_name:
+        flat["framework_name"] = framework_name
+
+    # Emit in the checker's published field order.
+    ordered = {k: flat[k] for k in _TRAINING_FIELD_ORDER if k in flat}
+    ordered.update({k: v for k, v in flat.items() if k not in ordered})
+    return ordered, None
 
 
 def _update_parsed_node_details(
@@ -800,9 +1048,15 @@ def postprocess(i):
         "measured_accuracy_score": env.get("MLC_MLPERF_MEASURED_ACCURACY_SCORE", ""),
     }
 
-    if env.get("MLC_MLPERF_BENCHMARK", "") == "inference":
+    benchmark = env.get("MLC_MLPERF_BENCHMARK", "")
+    if benchmark == "inference":
         output_info = _flatten_for_inference(output_info, env)
         logger.info("Using flat inference format for system_info.json")
+    elif benchmark == "training":
+        output_info, err = _flatten_for_training(output_info, env, logger)
+        if err:
+            return {'return': 1, 'error': err}
+        logger.info("Using flat training format for system_info.json")
 
     # Stamp the aggregated output with the git version of the automations repo
     # (the orchestrating node's checkout), plus each node's version so that a

--- a/script/get-mlperf-multi-node-system-info/info.md
+++ b/script/get-mlperf-multi-node-system-info/info.md
@@ -91,8 +91,17 @@ python -m vllm.entrypoints.openai.api_server ... > /tmp/serving.log 2>&1 &
 | `--submitter_contact` | string | Contact email for submission queries. |
 | `--system_name` | string | **Required.** Human-readable name for the system under test (e.g. `"8x NVIDIA H100 80GB HBM3"`). |
 | `--category` | string | System category (e.g. `"datacenter"`). |
-| `--status` | string | System availability status (e.g. `"available"`). |
+| `--system_availability_status` | string | System availability status (e.g. `"available"`). Under `_training` this must be one of the four values the training checker accepts — see [Training submission format](#training-submission-format). |
 | `--division` | string | Submission division (e.g. `"open"`, `"closed"`). |
+
+### Software metadata
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `--framework` | string | Training framework and version, e.g. `"NVIDIA PyTorch Release 25.04"`. Used by `_training` for the `framework` field. Distinct from `--serving_framework`, which is the inference serving stack. |
+| `--framework_name` | string | Optional short framework tag some training submitters carry alongside `framework`, e.g. `"ngc25.04_pytorch"`. Emitted only when set. |
+| `--sw_notes` | string | Free-form software notes. |
+| `--host_networking_topology` | string | Physical network topology (e.g. `"fat-tree"`). Not auto-detectable. |
 
 ### Model metadata
 
@@ -337,6 +346,7 @@ Specify one of `_cuda`, `_rocm`, or `_xpu` to match your hardware. If none is gi
 | Tag | Effect |
 |-----|--------|
 | `_inference` | Produces a flat `system_desc_id.json`-compatible output for MLPerf Inference submissions (see [Inference submission format](#inference-submission-format)). |
+| `_training` | Produces a flat `<system_desc_id>.json` for MLPerf Training submissions, validated by `mlperf_logging.system_desc_checker` (see [Training submission format](#training-submission-format)). |
 | `_endpoints` | Produces the nested format used for MLPerf Inference Endpoints submissions. |
 
 ### Stackable modifiers
@@ -525,5 +535,114 @@ The `accelerator_interconnect_topology` field is auto-derived from `nvidia-smi t
   "sw_notes": "",
   "other_hardware": "",
   "system_type_detail": ""
+}
+```
+
+## Training submission format
+
+With `_training`, the script writes the flat JSON that MLPerf Training submissions
+place at `<submitter>/systems/<system_desc_id>.json`. It is checked by
+`mlperf_logging.system_desc_checker` in
+[mlcommons/logging](https://github.com/mlcommons/logging/tree/master/mlperf_logging/system_desc_checker):
+
+```bash
+python3 -m mlperf_logging.system_desc_checker <file>.json training 6.1.0
+```
+
+The field set is nearly the same as `_inference` — the two checkers ask for
+almost identical hardware fields — but the output differs in four ways:
+
+- **Every value is a string.** Counts are written as `"8"`, not `8`, matching
+  existing submissions in the `training_results_v*` repos.
+- **Field order follows the checker's `required_fields` list**, so a generated
+  file diffs cleanly against a previous round's.
+- **`framework` is the training framework**, from `--framework`, *not*
+  `--serving_framework`. The optional `framework_name` field is emitted only
+  when `--framework_name` is given.
+- **`status` is validated**, since the training checker rejects anything
+  outside its four allowed values (for ruleset >= 4.1).
+
+The inference-only fields (`submitter_contact`, `system_type`,
+`system_type_detail`, `system_size`, `host_network_card_count`,
+`other_hardware`) are not part of the training schema and are omitted.
+
+### Availability status values
+
+`--system_availability_status` accepts the four canonical values plus the
+shorthands below, case-insensitively. Anything else fails the run with the
+list of valid values rather than producing a file the checker would reject:
+
+| Canonical value | Also accepted |
+|---|---|
+| `Available on-premise` | `on-premise`, `on-prem`, `onprem` |
+| `Available cloud` | `cloud` |
+| `Research, Development, or Internal (RDI)` | `rdi`, `internal` |
+| `Preview` | — |
+
+Bare `available` — the value MLPerf Inference uses — is deliberately rejected:
+training splits availability into on-premise and cloud, and guessing which one
+was meant would silently mislabel a submission.
+
+### Values that could not be detected
+
+Fields the probe could not fill (`"N/A"`, `"Not available"`, or a
+`"Not detected: ..."` reason string) are written as empty strings, which is how
+existing training submissions express "not disclosed". On heterogeneous
+clusters this normalization runs per node *before* values are merged, so one
+node failing to detect a field does not blank out the values its peers did
+detect.
+
+### Example
+
+```bash
+mlcr get-mlperf-multi-node-system-info,_cuda,_training \
+  --ssh_ids=user@node1:22,user@node2:22 \
+  --out_dir_path=/tmp/sysinfo \
+  --system_name="16xXE9712x4GB200" \
+  --submitter_org_name=MLCommons \
+  --division=closed \
+  --system_availability_status="Available on-premise" \
+  --framework="NVIDIA PyTorch Release 25.04" \
+  --framework_name=ngc25.04_pytorch
+```
+
+### Example flat output (`_training`)
+
+```json
+{
+  "submitter": "MLCommons",
+  "division": "closed",
+  "status": "Available on-premise",
+  "system_name": "16xXE9712x4GB200",
+  "number_of_nodes": "2",
+  "host_processors_per_node": "2",
+  "host_processor_model_name": "Intel(R) Xeon(R) Platinum 8480+",
+  "host_processor_core_count": "112",
+  "host_processor_vcpu_count": "224",
+  "host_processor_frequency": "3.80 GHz",
+  "host_processor_caches": "L1d: 4.5 MiB; L1i: 3 MiB; L2: 224 MiB; L3: 210 MiB",
+  "host_processor_interconnect": "",
+  "host_memory_capacity": "2.2T",
+  "host_storage_type": "NVMe SSD",
+  "host_storage_capacity": "1.8 TB NVMe SSD",
+  "host_networking": "mlx5_0: native InfiniBand",
+  "host_networking_topology": "",
+  "host_memory_configuration": "",
+  "accelerators_per_node": "8",
+  "accelerator_model_name": "NVIDIA H100 80GB HBM3",
+  "accelerator_host_interconnect": "PCIe Gen5 x16",
+  "accelerator_frequency": "1980 MHz",
+  "accelerator_on-chip_memories": "Shared Memory: 228 KB/block",
+  "accelerator_memory_configuration": "80 GiB HBM3",
+  "accelerator_memory_capacity": "80GiB",
+  "accelerator_interconnect": "NVLink",
+  "accelerator_interconnect_topology": "Mesh",
+  "cooling": "",
+  "hw_notes": "",
+  "framework": "NVIDIA PyTorch Release 25.04",
+  "framework_name": "ngc25.04_pytorch",
+  "other_software_stack": "CUDA 12.9, Driver 575.57.08",
+  "operating_system": "ubuntu 24.04",
+  "sw_notes": ""
 }
 ```

--- a/script/get-mlperf-multi-node-system-info/meta.yaml
+++ b/script/get-mlperf-multi-node-system-info/meta.yaml
@@ -26,6 +26,9 @@ input_mapping:
   dataset_name: MLC_MLPERF_DATASET_NAME
   dataset_type: MLC_MLPERF_DATASET_TYPE
   division: MLC_MLPERF_SUBMISSION_DIVISION
+  framework: MLC_MLPERF_FRAMEWORK
+  framework_name: MLC_MLPERF_FRAMEWORK_NAME
+  host_networking_topology: MLC_MLPERF_HOST_NETWORKING_TOPOLOGY
   hw_notes: MLC_MLPERF_HARDWARE_NOTES
   input_token_average: MLC_MLPERF_DATASET_INPUT_TOKEN_AVERAGE
   link_to_dataset: MLC_MLPERF_DATASET_LINK
@@ -41,6 +44,7 @@ input_mapping:
   output_token_average: MLC_MLPERF_DATASET_OUTPUT_TOKEN_AVERAGE
   skip_ssh_key_file: MLC_SKIP_SSH_KEY_FILE
   ssh_ids: MLC_MULTINODE_SYSTEM_SSH_IDS
+  sw_notes: MLC_MLPERF_SOFTWARE_NOTES
   system_availability_status: MLC_MLPERF_SUBMISSION_SYSTEM_STATUS
   submitter_contact: MLC_MLPERF_SUBMITTER_CONTACT
   submitter_org_name: MLC_MLPERF_SUBMITTER
@@ -152,6 +156,10 @@ variations:
     group: mlperf-benchmark
     env:
       MLC_MLPERF_BENCHMARK: endpoints
+  training:
+    group: mlperf-benchmark
+    env:
+      MLC_MLPERF_BENCHMARK: training
   network:
     env:
       MLC_MLPERF_NETWORK_VARIATION: 'True'


### PR DESCRIPTION
## What this adds

`get-mlperf-multi-node-system-info` could already emit the nested JSON that **Inference** and **Endpoints** submissions use. It could not emit the flat `<system_desc_id>.json` that **Training** submissions need. This adds a `_training` variation that does.

## Why the field set looks the way it does

Training system descriptions are validated by `mlperf_logging/system_desc_checker/`, which is a **different** checker from the Inference `submission_checker` — the two formats drift independently. So the fields here are derived from that checker directly rather than by analogy to `_inference`:

- 33 required fields
- `status` is constrained to one of four accepted values once the ruleset major version is 4 or above

## New inputs

| Flag | Env |
|---|---|
| `--division` | `MLC_MLPERF_SUBMISSION_DIVISION` |
| `--framework` | `MLC_MLPERF_FRAMEWORK` |
| `--framework_name` | `MLC_MLPERF_FRAMEWORK_NAME` |
| `--host_networking_topology` | `MLC_MLPERF_HOST_NETWORKING_TOPOLOGY` |
| `--sw_notes` | `MLC_MLPERF_SOFTWARE_NOTES` |
| `--system_availability_status` | `MLC_MLPERF_SUBMISSION_SYSTEM_STATUS` |

Note that the flag is `--system_availability_status`, not `--status`.

## Testing

Run on a single box (Intel i9-14900KS / NVIDIA RTX 5060 Ti / Ubuntu 24.04). Multi-node was simulated by passing the same SSH id eight times with `_exclude_current_node`, and the Endpoints case used a `node_config` of 4 Prefill + 4 Decode nodes.

Six scenarios, covering all three working groups:

| Scenario | Result |
|---|---|
| Inference, local | unchanged, byte for byte |
| Inference, `_network,_power` | unchanged, byte for byte |
| Inference, 8 nodes | unchanged, byte for byte |
| Endpoints, 8 nodes, 4 Prefill + 4 Decode | unchanged, byte for byte |
| Training, local | new output |
| Training, 8 nodes from a config file | new output |

Both Training outputs pass `system_desc_checker` at rulesets **5.0.0** and **6.1.0**. A synthetic heterogeneous two-node fixture was also checked.

Existing Inference and Endpoints output is untouched — that was verified by diffing rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)