### PR TITLE
Fix NumPy 2.0 incompatibility in app-loadgen-generic-python onnxruntime backend

### DIFF
--- a/script/app-loadgen-generic-python/src/backend_onnxruntime.py
+++ b/script/app-loadgen-generic-python/src/backend_onnxruntime.py
@@ -21,7 +21,7 @@ ONNX_TO_NP_TYPE_MAP = {
     "tensor(float16)": np.float16,
     "tensor(float)": np.float32,
     "tensor(double)": np.float64,
-    "tensor(string)": np.string_,
+    "tensor(string)": np.bytes_,
 }
 
 


### PR DESCRIPTION
## The failure

The `MLPerf loadgen with HuggingFace bert onnx fp32 squad model` workflow fails on every PR that reaches it ([example run](https://github.com/mlcommons/mlperf-automations/actions/runs/34084305848/job/101625300208)):

```
File "script/app-loadgen-generic-python/src/backend_onnxruntime.py", line 24, in <module>
    "tensor(string)": np.string_,
                      ^^^^^^^^^^
AttributeError: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead.
```

It dies at **import time**, before the model is ever loaded.

## Why it started happening

The numpy dependency is unpinned:

```yaml
- tags: get,generic-python-lib,_package.numpy
```

so a fresh environment now resolves NumPy 2.x, where `np.string_` no longer exists. Fixing the source is preferable to pinning the dep back below 2.0.

`np.bytes_` is not a new spelling — on NumPy 1.x it is the same object:

```
numpy 1.26.4
np.string_ is np.bytes_: True
```

So the change is a no-op on 1.x and correct on 2.x. This is the only occurrence of a NumPy-2-removed alias in the repo:

```
$ grep -rnE "np\.(string_|unicode_|float_|complex_|bool8|int0|uint0|NaN|Inf|infty)\b" --include=*.py script/
script/app-loadgen-generic-python/src/backend_onnxruntime.py:24:    "tensor(string)": np.string_,
```

## Verification

**Reproduced under NumPy 2.5.3** — before the change, importing the module raises the identical `AttributeError` at the same line as CI. After the change it imports cleanly and `tensor(string)` maps to `<class 'numpy.bytes_'>`.

**No regression on NumPy 1.x** — the workflow's own command was run locally under python3.9 / NumPy 1.26.4:

```
mlcr python,app,loadgen-generic,_onnxruntime,_custom,_huggingface,_model-stub.ctuning/mlperf-inference-bert-onnx-fp32-squad-v1.1 --quiet
```

```
Observed QPS: 4.63475
Result: VALID
Test Completed
No warnings encountered during test.
No errors encountered during test.
```

That local run exercises NumPy 1.x rather than 2.x, so it only shows the change is harmless there. The NumPy 2 side is covered by the import reproduction above and by this PR's CI, which installs `numpy-2.5.3` and reaches `Result: VALID` on the job that fails without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
