### PR TITLE
Author format commits as the App's own bot user

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
           path-to-signatures: 'cla-bot/v1/cla.json'
           # branch should not be protected
           branch: 'main'
-          allowlist: user1,mlcommons-bot,mlc-automations,bot*,copilot-swe-agent[bot],Copilot*,github-actions
+          allowlist: user1,mlcommons-bot,mlc-automations[bot],bot*,copilot-swe-agent[bot],Copilot*,github-actions
           remote-organization-name: mlcommons
           remote-repository-name: systems
           

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -82,8 +82,8 @@ jobs:
         run: |
           HAS_CHANGES=$(git diff --staged --name-only)
           if [ ${#HAS_CHANGES} -gt 0 ]; then
-            git config --global user.name '${{ steps.bot.outputs.name }}'
-            git config --global user.email '${{ steps.bot.outputs.email }}'
+            git config --global user.name "${{ steps.bot.outputs.name }}"
+            git config --global user.email "${{ steps.bot.outputs.email }}"
             # Commit changes
             git commit -m '[Automated Commit] Format Codebase'
             git push 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   format-code:
-    if: github.actor != 'mlc-automations' && github.repository_owner == 'mlcommons'
+    if: github.actor != 'mlc-automations[bot]' && github.repository_owner == 'mlcommons'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,6 +21,18 @@ jobs:
         with:
           app-id: ${{ secrets.MLC_AUTOMATIONS_APP_ID }}
           private-key: ${{ secrets.MLC_AUTOMATIONS_PRIVATE_KEY }}
+
+      - name: Resolve the App's bot identity
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          slug: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          # GitHub links a noreply address by the numeric id inside it and ignores
+          # the name, so the App's bot user id has to be looked up, not written down.
+          id=$(gh api "/users/${slug}%5Bbot%5D" --jq .id)
+          echo "name=${slug}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,9 +82,8 @@ jobs:
         run: |
           HAS_CHANGES=$(git diff --staged --name-only)
           if [ ${#HAS_CHANGES} -gt 0 ]; then
-            # Use the GitHub actor's name and email
-            git config --global user.name mlc-automations
-            git config --global user.email "3246381+mlc-automations@users.noreply.github.com"
+            git config --global user.name '${{ steps.bot.outputs.name }}'
+            git config --global user.email '${{ steps.bot.outputs.email }}'
             # Commit changes
             git commit -m '[Automated Commit] Format Codebase'
             git push 


### PR DESCRIPTION
## Problem

`format.yml` pushes with the `mlc-automations` GitHub App token, but hardcoded a **user** account as the commit author:

```yaml
git config --global user.name mlc-automations
git config --global user.email "3246381+mlc-automations@users.noreply.github.com"
```

GitHub resolves `<id>+<name>@users.noreply.github.com` by the **numeric id** and ignores the name entirely. Id `3246381` is not the App — the App's bot user is id `272923709`:

```
$ gh api /users/mlc-automations%5Bbot%5D --jq '{login,id,type}'
{"login":"mlc-automations[bot]","id":272923709,"type":"Bot"}
```

So every `[Automated Commit] Format Codebase` commit has been credited to account `3246381`, a separate user account. That account is now named `bumper97birch`, and `github.com/bumper97birch`, `GET /users/bumper97birch` and the GraphQL node lookup all return 404 / `NOT_FOUND`.

`cla-bot` resolves those commits to an unsigned contributor and fails the check on any PR the format bot has committed to. The display name still reads `mlc-automations` because that string is baked into the commit, which is what made this confusing to diagnose.

## Effect today

Six open PRs are blocked: #1074, #1057, #1044, #1003, #916, #912.

This passed until recently because the CLA allowlist named `mlc-automations` and account 3246381 carried that login. The last green run with a format commit was #1061 (3 Aug); the first failure was #1074 (18 Aug), so the rename landed in that window.

## Changes

1. **`format.yml`** — resolve the App's bot user id at run time from `steps.app-token.outputs.app-slug`, per the [`create-github-app-token` README](https://github.com/actions/create-github-app-token#commit-signing--attribution), rather than hardcoding a number that can silently go stale.
2. **`cla.yml`** — allowlist `mlc-automations[bot]` instead of `mlc-automations`. Note `bot*` is a *prefix* glob and does not cover `...[bot]`, so the explicit entry is required. Dropping the stale entry matters independently: `mlc-automations` is currently an unclaimed GitHub username, so anyone who registered it would have been auto-allowlisted on this repo.
3. **`format.yml` skip guard** — `github.actor != 'mlc-automations'` never matched, because an App-token push sets the actor to `mlc-automations[bot]`. The workflow has been re-triggering on its own format commits (visible on `a8e187953`, actor `mlc-automations[bot]`). Harmless, as autopep8 is idempotent, but it burned a run each time.

## No history rewrite needed

The 44 commits already on `main` are untouched. [`cla-bot/src/graphql.ts`](https://github.com/mlcommons/cla-bot/blob/master/src/graphql.ts) queries `pullRequest.commits`, i.e. only commits reachable from the head branch and not the base — so merged history is never re-inspected. Confirmed empirically: all 20 PRs merged since the rename passed CLA cleanly.

Rewriting `main` would also invalidate every fork, clone, open PR base and recorded release-provenance hash, for no benefit.

Once this lands, the six branches above need a rebase; the bot will recreate the format commits with the correct identity.

## Open question

Whether account `3246381` was ever under the MLCommons organization, and what it was originally intended to be, is not answerable from outside — the account is not resolvable through any public endpoint. The org audit log or GitHub Support can confirm. It does not block this fix.

---

### 🧾 PR Checklist

- [x] No unintended files committed
- [x] Inline comments explain the non-obvious part (why the id is looked up rather than written down)
- [x] PR title and description state what and why
- [x] No secrets or credentials committed
- [x] YAML validated; the resolve step was run locally and produces `272923709+mlc-automations[bot]@users.noreply.github.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
